### PR TITLE
SuperSIDonRaspi3.md

### DIFF
--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -77,4 +77,15 @@ ftp_server = sid-ftp.stanford.edu
 ftp_directory = /incoming/SuperSID/NEW/
 # local_tmp shall be an absolute path or a path relative to the supersid script folder
 local_tmp = ../outgoing
-call_signs = NWC
+call_signs = NWC   
+
+[Email]
+from_mail =  
+email_server =   
+email_port =  
+email_tls =  
+email_login =  
+email_password =  
+
+# email_server for gmail would be smtp.gmail.com  
+# email_port for gmail would be 587  

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -85,7 +85,7 @@ email_server =
 email_port =  
 email_tls =  
 email_login =  
-email_password =  
+email_password =   
 
 # email_server for gmail would be smtp.gmail.com  
 # email_port for gmail would be 587  

--- a/docs/SuperSIDonRaspi3.md
+++ b/docs/SuperSIDonRaspi3.md
@@ -14,7 +14,7 @@ If you intend to access your system remotely you must enable SSH and VNC.
 To do this, click on the Raspberry icon in the upper left of the screen.   
 From the drop down, choose Preferences > Raspberry Pi Configuration. Under the Interface tab, Enable SSH & VNC.      
 Move your cursor to the upper right of the window and hover over the icon that will show the wlan0 (WiFi) address that your router has assigned to the RPi. You will need to record this address (192.168.1.xxx) in order to access via SSH or VNC.   
-When complete, open a terminal window type fbset to find the current screen resolution and record it.   
+When complete, open a terminal window type fbset to find the current screen resolution and record it.  In the event that VNC gives you the error "currently cannot show desktop" you will have to lower the screen resolution.
 
 ## 1) Get the latest supersid software
 
@@ -329,7 +329,7 @@ In the [FTP] section of supersid.cfg, set “automatic_upload” to yes and add 
 The supersid.cfg file uses the /home/pi/tmp directory to store the files to be sent via ftp.
 Sending the ftp is accomplished by the program ftp_to_stanford.py   
 Using the following procedure, crontab can be used to run the program at a specific time each day.   
-In a terminal window create a script in the /home/pi directory by typing nano ftp_stanford.sh   The script should contain the following: 
+In a terminal window create a script in the /home/pi directory by typing **nano ftp_stanford.sh**   The script should contain the following: 
 
 #!/bin/bash   
 cd ~/supersid/supersid   
@@ -344,7 +344,7 @@ Make it executable by doing:
     $ sudo chmod +x ftp_stanford.sh 
 ```
 
-In a terminal window type sudo crontab -e.  Choose #1 for the nano editor.  
+In a terminal window type **sudo crontab -e**  Choose #1 for the nano editor.  
 
 Add the following at the bottom of the file:
 

--- a/docs/SuperSIDonRaspi3.md
+++ b/docs/SuperSIDonRaspi3.md
@@ -329,7 +329,15 @@ In the [FTP] section of supersid.cfg, set “automatic_upload” to yes and add 
 The supersid.cfg file uses the /home/pi/tmp directory to store the files to be sent via ftp.
 Sending the ftp is accomplished by the program ftp_to_stanford.py   
 Using the following procedure, crontab can be used to run the program at a specific time each day.   
-In a terminal window create a script in the /home/pi directory by typing **nano ftp_stanford.sh**   The script should contain the following: 
+In a terminal window create a script in the /home/pi directory by typing:
+
+
+```console
+    $ nano ftp_stanford.sh
+```
+
+
+The script should contain the following: 
 
 #!/bin/bash   
 cd ~/supersid/supersid   
@@ -344,7 +352,15 @@ Make it executable by doing:
     $ sudo chmod +x ftp_stanford.sh 
 ```
 
-In a terminal window type **sudo crontab -e**  Choose #1 for the nano editor.  
+In a terminal window type:
+
+
+```console
+    sudo crontab -e
+```
+
+
+Choose #1 for the nano editor.  
 
 Add the following at the bottom of the file:
 


### PR DESCRIPTION
A few edits to the doc.  I believe that the name should be changed to SuperSIDonRaspi.md  The Raspberry Pi 4 is now available and the code can be used on the Pi 3, Pi 4, Pi Zero, etc.

I did not do anything concerning line 77 or line 167 as mentioned in your email of 12/29.  Should sections 5) and 6) stay the way they are?

