### PR TITLE
issue sberl/66: fixed use of unknown variable

### DIFF
--- a/supersid/supersid_plot.py
+++ b/supersid/supersid_plot.py
@@ -441,7 +441,7 @@ if __name__ == '__main__':
     if args.filename is None:  # no --file option specified
         if len(args.file_list) > 0:
             # last non options arguments are assumed to be a list of file names
-            filenames = ",".join(unk)
+            filenames = ",".join(args.file_list)
         else:
             # try building the file name from given options
             # or found in the provided .cfg file


### PR DESCRIPTION
https://github.com/sberl/supersid/issues/66 
replaced unknown variable `unk` with `args.file_list`
