### PR TITLE
issue sberl/55: fixed wrong station number in error report

### DIFF
--- a/supersid/config.py
+++ b/supersid/config.py
@@ -311,7 +311,7 @@ class Config(dict):
                 self.config_ok = False
                 self.config_err = \
                     "[STATION_{}] {}={} must be >= 0 and < 'Channels'={}." \
-                    .format(i, CHANNEL, station[CHANNEL], self['Channels'])
+                    .format(i+1, CHANNEL, station[CHANNEL], self['Channels'])
                 return
             if ((self['audio_sampling_rate'] // 2) < int(station[FREQUENCY])):
                 # configured sampling rate is below Nyquist sampling rate
@@ -319,7 +319,7 @@ class Config(dict):
                 self.config_err = "[STATION_{}] {}={}: " \
                     "audio_sampling_rate={} must be >= {}." \
                     .format(
-                        i, FREQUENCY, station[FREQUENCY],
+                        i+1, FREQUENCY, station[FREQUENCY],
                         self['audio_sampling_rate'], int(station[FREQUENCY])*2
                         )
                 return


### PR DESCRIPTION
fixed wrong station number in error report for bad channel or frequency