### PR TITLE
issue sberl/47: removed unused configuration option 'mode'

### DIFF
--- a/supersid/config.py
+++ b/supersid/config.py
@@ -94,9 +94,6 @@ class Config(dict):
                 # suitable for automatic FTP upload
                 ('log_format', str, SUPERSID_EXTENDED),
 
-                # Server, Client, Standalone (default)
-                ('mode', str, 'Standalone'),
-
                 # text, tk (default)
                 ('viewer', str, 'tk'),
 

--- a/supersid/textsidviewer.py
+++ b/supersid/textsidviewer.py
@@ -1,7 +1,6 @@
 """SuperSID text mode viewer.
 
 Minimal output for SuperSID in text mode i.e. within terminal window.
-Useful for Server mode
 
 Each Viewer must implement:
 - __init__(): all initializations


### PR DESCRIPTION
fix for https://github.com/sberl/supersid/issues/47