### PR TITLE
Audio Sampler improvements

### DIFF
--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -84,8 +84,8 @@ channel = 0
 #Channels = 1
 
 # Windows example using either sounddevice or pyaudio
-#Audio = sounddevice
-Audio = pyaudio
+Audio = sounddevice
+#Audio = pyaudio
 #Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
 Device = MME: Microsoft Sound Mapper - Input
 Format = S32_LE

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -9,6 +9,8 @@ viewer = tk
 #sampler = normal
 sampler = gapless
 
+overlap = True
+
 site_name = EXAMPLE
 monitor_id = SAMPLE1
 contact = you@domain.tld

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -3,14 +3,8 @@
 # Comments are added only for demonstration purpose.
 
 [PARAMETERS]
-viewer = tk
-# viewer = text
-
-#sampler = normal
-sampler = gapless
-
-overlap = True
-
+# viewer = tk
+viewer = text
 site_name = EXAMPLE
 monitor_id = SAMPLE1
 contact = you@domain.tld
@@ -21,7 +15,7 @@ latitude = 51.478
 utc_offset = +00:00
 time_zone = UTC
 
-audio_sampling_rate = 96000
+audio_sampling_rate = 48000
 
 log_interval = 5
 log_format = supersid_extended
@@ -77,19 +71,18 @@ channel = 0
 
 [Capture]
 # Linux example using alsaaudio
-#Audio = alsaaudio
-#Device = plughw:CARD=Generic,DEV=0
-#Format = S16_LE
-#PeriodSize = 1024
-#Channels = 1
+Audio = alsaaudio
+Device = plughw:CARD=Generic,DEV=0
+Format = S16_LE
+PeriodSize = 1024
+Channels = 1
 
 # Windows example using either sounddevice or pyaudio
-Audio = sounddevice
-#Audio = pyaudio
-#Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
-Device = MME: Microsoft Sound Mapper - Input
-Format = S32_LE
-Channels = 1
+# Audio = sounddevice
+# Audio = pyaudio
+# Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
+# Format = S32_LE
+# Channels = 1
 
 [FTP]
 automatic_upload = no

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -5,6 +5,10 @@
 [PARAMETERS]
 viewer = tk
 # viewer = text
+
+#sampler = normal
+sampler = gapless
+
 site_name = EXAMPLE
 monitor_id = SAMPLE1
 contact = you@domain.tld
@@ -78,8 +82,8 @@ channel = 0
 #Channels = 1
 
 # Windows example using either sounddevice or pyaudio
-Audio = sounddevice
-#Audio = pyaudio
+#Audio = sounddevice
+Audio = pyaudio
 #Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
 Device = MME: Microsoft Sound Mapper - Input
 Format = S32_LE

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -3,8 +3,8 @@
 # Comments are added only for demonstration purpose.
 
 [PARAMETERS]
-# viewer = tk
-viewer = text
+viewer = tk
+# viewer = text
 site_name = EXAMPLE
 monitor_id = SAMPLE1
 contact = you@domain.tld
@@ -15,7 +15,7 @@ latitude = 51.478
 utc_offset = +00:00
 time_zone = UTC
 
-audio_sampling_rate = 48000
+audio_sampling_rate = 96000
 
 log_interval = 5
 log_format = supersid_extended

--- a/Config/supersid.cfg
+++ b/Config/supersid.cfg
@@ -71,18 +71,19 @@ channel = 0
 
 [Capture]
 # Linux example using alsaaudio
-Audio = alsaaudio
-Device = plughw:CARD=Generic,DEV=0
-Format = S16_LE
-PeriodSize = 1024
-Channels = 1
+#Audio = alsaaudio
+#Device = plughw:CARD=Generic,DEV=0
+#Format = S16_LE
+#PeriodSize = 1024
+#Channels = 1
 
 # Windows example using either sounddevice or pyaudio
-# Audio = sounddevice
-# Audio = pyaudio
-# Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
-# Format = S32_LE
-# Channels = 1
+Audio = sounddevice
+#Audio = pyaudio
+#Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
+Device = MME: Microsoft Sound Mapper - Input
+Format = S32_LE
+Channels = 1
 
 [FTP]
 automatic_upload = no

--- a/supersid/config.py
+++ b/supersid/config.py
@@ -123,6 +123,9 @@ class Config(dict):
                 # normal (default), gapless
                 ('sampler', str, 'normal'),
 
+                # Whether to use overlap in computing the FFTs
+                ('overlap', bool, False),
+
                 #####################
                 # mandatory entries #
                 #####################

--- a/supersid/config.py
+++ b/supersid/config.py
@@ -119,6 +119,10 @@ class Config(dict):
                 # 0 means waterfall diagram is disabled
                 ('waterfall_samples', int, 0),
 
+                # What sampler and timing mode to use
+                # normal (default), gapless
+                ('sampler', str, 'normal'),
+
                 #####################
                 # mandatory entries #
                 #####################
@@ -397,7 +401,14 @@ class Config(dict):
             self.config_ok = False
             self.config_err = "'viewer' must be either one of 'text', 'tk'."
             return
-
+        
+        # check sampler
+        self['sampler'] = self['sampler'].lower()
+        if self['sampler'] not in ('gapless', 'normal'):
+            self.config_ok = False
+            self.config_err = "'sampler' must be either one of 'normal', 'gapless'."
+            return
+        
         # Check the 'data_path' validity
         # and create it as a Config instance property
         self['data_path'] = script_relative_to_cwd_relative(self['data_path'])\

--- a/supersid/gapless_sampler.py
+++ b/supersid/gapless_sampler.py
@@ -281,7 +281,7 @@ try:
             self.bufferStartTime = time.time()
             
             #Drop a number of samples in order to get to the next 5 second interval.
-            dropsamples = int((5 - datetime.datetime.fromtimestamp(self.bufferStartTime).second % 5) * self.audio_sampling_rate)
+            dropsamples = int(((5 - datetime.datetime.fromtimestamp(self.bufferStartTime).second % 5) + (datetime.datetime.fromtimestamp(self.bufferStartTime).microsecond / 1000000)) * self.audio_sampling_rate)
             self.stream.read(dropsamples)
             self.bufferStartTime = int(self.bufferStartTime + dropsamples / self.audio_sampling_rate) + 1
 

--- a/supersid/gapless_sampler.py
+++ b/supersid/gapless_sampler.py
@@ -168,6 +168,7 @@ try:
                                          rate=audio_sampling_rate,
                                          format=self.FORMAT_MAP[self.format],
                                          periodsize=periodsize,
+                                         periods=256,
                                          device=device)
             
             
@@ -496,7 +497,7 @@ try:
                 channels=self.channels,
                 rate=self.audio_sampling_rate,
                 input=True,
-                frames_per_buffer=self.CHUNK,
+                frames_per_buffer=audio_sampling_rate * 10,
                 input_device_index=self.input_device_index)
             self.pa_stream.start_stream()
             self.audioTime = int(time.time() * audio_sampling_rate)

--- a/supersid/gapless_sampler.py
+++ b/supersid/gapless_sampler.py
@@ -1,0 +1,945 @@
+#!/usr/bin/env python3
+"""
+Sampler handles audio data capture.
+
+Also handles calculating PSD, extracting signal strengths at monitored
+frequencies, saving spectrum and spectrogram (image) to png file
+
+The Sampler class will use an audio 'device' to capture 1 second of sound.
+This 'device' can be a local sound card:
+     - controlled by sounddevice or pyaudio on Windows or other system
+     - controlled by alsaaudio on Linux
+    or this 'device' can be a remote server
+     - client mode accessing server thru TCP/IP socket (to be implemented)
+
+    All these 'devices' must implement:
+     - __init__: open the 'device' for future capture
+     - capture_1sec: obtain one second of sound and return as an array
+        of 'audio_sampling_rate' integers
+     - close: close the 'device'
+"""
+import sys
+import time
+import argparse
+import traceback
+import numpy
+import datetime
+from struct import unpack as st_unpack
+from numpy import array
+from matplotlib.mlab import psd as mlab_psd
+
+from config import FREQUENCY, S16_LE, S24_3LE, S32_LE
+
+
+def get_peak_freq(data, audio_sampling_rate):
+    # NFFT = 1024 for 44100 and 48000,
+    #        2048 for 96000,
+    #        4096 for 192000
+    # -> the frequency resolution is constant
+    NFFT = max(1024, 1024 * audio_sampling_rate // 48000)
+    Pxx, freqs = mlab_psd(data, NFFT, audio_sampling_rate)
+    m = max(Pxx)
+    if m == min(Pxx):
+        peak_freq = 0
+    else:
+        pos = [i for i, j in enumerate(Pxx) if j == m]
+        peak_freq = int(freqs[pos][0])
+    return peak_freq
+
+
+audioModule = []
+try:
+    import alsaaudio  # for Linux direct sound capture
+    audioModule.append("alsaaudio")
+
+    def alsaaudio_test(device, sampling_rate, format, channels, periodsize):
+        print()
+        try:
+            print(
+                "Accessing '{}' at {} Hz via alsaaudio "
+                "format {}, channels {}..."
+                .format(device, sampling_rate, format, channels))
+            sc = alsaaudio_soundcard(
+                '',
+                device,
+                sampling_rate,
+                format,
+                channels,
+                periodsize)
+            sc.info()
+            return True
+        except alsaaudio.ALSAAudioError as err:
+            print(err)
+            return False
+
+    class alsaaudio_soundcard():
+        """Sampler for an ALSA audio device."""
+        # map ALSA format string to module format
+        FORMAT_MAP = {
+            # Signed 16 bit samples stored in 2 bytes, Little Endian byte order
+            S16_LE: alsaaudio.PCM_FORMAT_S16_LE,
+
+            # Signed 24 bit samples stored in 3 bytes, Little Endian byte order
+            S24_3LE: alsaaudio.PCM_FORMAT_S24_3LE,
+
+            # Signed 32 bit samples stored in 4 bytes, Little Endian byte order
+            S32_LE: alsaaudio.PCM_FORMAT_S32_LE,
+        }
+
+        # map ALSAO format string to length of one sample in bytes
+        FORMAT_LENGTHS = {
+            S16_LE: 2,
+            S24_3LE: 3,
+            S32_LE: 4,
+        }
+
+        def __init__(
+                self,
+                card,
+                device,
+                audio_sampling_rate,
+                format,
+                channels,
+                periodsize):
+            """
+            Initialize the ALSA audio sampler.
+            card is deprecated but still present for backward compatibility
+            device is preferred
+            """
+
+            # time to capture 1 sec of data excluding the format conversion
+            self.duration = None
+
+            self.format = format
+            self.channels = channels
+            self.audio_sampling_rate = audio_sampling_rate
+            if card != '':
+                # deprecated configuration keyword Card, use Device instead
+                # alsaaudio.PCM(card=card) deprecated since pyalsaaudio 0.8.0
+                # the device name would be built as 'default:CARD=' + card
+                # it has been observed, that default fails often,
+                # thus guessing the device name as 'sysdefault:CARD=' + card
+                device = 'sysdefault:CARD=' + card
+                print(
+                    "alsaaudio card '{}', "
+                    "sampling rate {}, "
+                    "format {}, "
+                    "channels {}, "
+                    "periodsize {}"
+                    .format(
+                        card,
+                        audio_sampling_rate,
+                        format,
+                        channels,
+                        periodsize))
+
+                self.inp = alsaaudio.PCM(alsaaudio.PCM_CAPTURE,
+                                         alsaaudio.PCM_NORMAL,
+                                         channels=self.channels,
+                                         rate=audio_sampling_rate,
+                                         format=self.FORMAT_MAP[self.format],
+                                         periodsize=periodsize,
+                                         device=device)
+                self.name = "alsaaudio Device guessed as '{}'".format(device)
+            else:
+                print(
+                    "alsaaudio device '{}', "
+                    "sampling rate {}, "
+                    "format {}, "
+                    "channels {}, "
+                    "periodsize {}"
+                    .format(
+                        device,
+                        audio_sampling_rate,
+                        format,
+                        channels,
+                        periodsize))
+                self.inp = alsaaudio.PCM(alsaaudio.PCM_CAPTURE,
+                                         alsaaudio.PCM_NORMAL,
+                                         channels=self.channels,
+                                         rate=audio_sampling_rate,
+                                         format=self.FORMAT_MAP[self.format],
+                                         periodsize=periodsize,
+                                         device=device)
+                self.name = "alsaaudio '{}'".format(device)
+
+        def capture_1sec(self):
+            """
+            return one second recording as numpy array
+            after unpacking, the format is
+                for Channels = 1: [left, ..., left]
+                for Channels = 2: [left, right ..., left, right]
+
+            the returned data format is
+                for Channels = 1: [[left], ..., [left]]
+                for Channels = 2: [[left, right], ..., [left, right]]
+
+            access the left channel as unpacked_data[:, 0]
+            access the right channel as unpacked_data[:, 1]
+            """
+            raw_data = b''
+            num_bytes = self.FORMAT_LENGTHS[self.format] \
+                * self.channels \
+                * self.audio_sampling_rate
+            t = time.time()
+            while len(raw_data) < num_bytes:
+                length, data = self.inp.read()
+                if length > 0:
+                    raw_data += data
+            self.duration = time.time() - t
+
+            # truncate to one second, if we received too much
+            raw_data = raw_data[:num_bytes]
+
+            if self.format == S16_LE:
+                unpacked_data = array(st_unpack(
+                    "<%ih" % (self.audio_sampling_rate * self.channels),
+                    raw_data))
+                return unpacked_data.reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            elif self.format == S24_3LE:
+                unpacked_data = []
+                for i in range(self.audio_sampling_rate * self.channels):
+                    chunk = raw_data[i*3:i*3+3]
+                    unpacked_data.append(st_unpack(
+                        '<i',
+                        chunk + (b'\0' if chunk[2] < 128 else b'\xff'))[0])
+                return array(unpacked_data).reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            elif self.format == S32_LE:
+                unpacked_data = array(st_unpack(
+                    "<%ii" % (self.audio_sampling_rate * self.channels),
+                    raw_data))
+                return unpacked_data.reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            else:
+                raise NotImplementedError(
+                    "Format conversion for '{}' is not yet implemented!"
+                    .format(self.format))
+
+        def close(self):
+            pass  # to check later if there is something to do
+
+        def info(self):
+            print(self.name, "at", self.audio_sampling_rate, "Hz")
+            try:
+                one_sec = self.capture_1sec()
+                text_data = ""
+                text_vector_sum = "Vector sum"
+                peak_freq = []
+                for channel in range(self.channels):
+                    channel_one_sec = one_sec[:, channel]
+                    peak_freq.append(get_peak_freq(
+                        channel_one_sec,
+                        self.audio_sampling_rate))
+                    text_data += "[{} ... {}], ".format(
+                        " ".join(str(i) for i in channel_one_sec[:5]),
+                        " ".join(str(i) for i in channel_one_sec[-5:]))
+                    text_vector_sum += " {},".format(channel_one_sec.sum())
+                print(
+                    "{:6d} "
+                    "{} "
+                    "read from {}, "
+                    "shape {}, "
+                    "format {}, "
+                    "channel {}, "
+                    "duration {:3.2f} sec, "
+                    "peak freq {} Hz"
+                    .format(
+                        len(channel_one_sec),
+                        type(channel_one_sec[0]),
+                        self.name,
+                        one_sec.shape,
+                        self.format,
+                        channel,
+                        self.duration,
+                        peak_freq))
+                print(text_data)
+                print(text_vector_sum)
+            except Exception as err:
+                print("Exception", type(err), err)
+
+except ImportError:
+    pass
+
+
+try:
+    # for Linux and Windows http://python-sounddevice.readthedocs.org
+    import sounddevice
+    audioModule.append("sounddevice")
+
+    def sounddevice_test(device, sampling_rate, format, channels):
+        print()
+        try:
+            print(
+                "Accessing '{}' at {} Hz via sounddevice "
+                "format {}, channels {}..."
+                .format(device, sampling_rate, format, channels))
+            sc = sounddevice_soundcard(device, sampling_rate, format, channels)
+            sc.info()
+            return True
+        except Exception as err:
+            print(err)
+            return False
+
+    class sounddevice_soundcard():
+        # map ALSA format string to module format
+        FORMAT_MAP = {
+            # Signed 16 bit samples stored in 2 bytes, Little Endian byte order
+            S16_LE: 'int16',
+
+            # Signed 24 bit samples stored in 3 bytes, Little Endian byte order
+            S24_3LE: 'int24',
+
+            # Signed 32 bit samples stored in 4 bytes, Little Endian byte order
+            S32_LE: 'int32',
+        }
+
+        def __init__(
+                self,
+                device_name,
+                audio_sampling_rate,
+                format,
+                channels):
+            print(
+                "sounddevice device '{}', "
+                "sampling rate {}, "
+                "format {}, "
+                "channels {}"
+                .format(
+                    device_name,
+                    audio_sampling_rate,
+                    format,
+                    channels))
+
+            # time to capture 1 sec of data excluding the format conversion
+            self.duration = None
+
+            self.audio_sampling_rate = audio_sampling_rate
+            self.device_name = device_name
+            self.format = format
+            self.channels = channels
+            sounddevice.default.samplerate = audio_sampling_rate
+            sounddevice.default.device = self.get_device_by_name(
+                self.device_name)
+            sounddevice.default.channels = self.channels
+            sounddevice.default.latency = 'low'
+            sounddevice.default.dtype = 'int16'
+            self.name = "sounddevice '{}'".format(self.device_name)
+            self.stream = sounddevice.InputStream()
+            self.stream.start()
+            self.localbuffer = array([])
+            self.bufferStartTime = time.time()
+            
+
+        @staticmethod
+        def query_input_devices():
+            input_device_names = []
+            for device_info in sounddevice.query_devices():
+                # we are interrested only in input devices
+                if device_info['max_input_channels'] > 0:
+                    hostapi_name = sounddevice.query_hostapis(
+                        device_info['hostapi'])['name']
+                    input_device_names.append(
+                        "{}: {}"
+                        .format(hostapi_name, device_info['name']))
+            return input_device_names
+
+        @staticmethod
+        def get_device_by_name(device_name):
+            if str == type(device_name):
+                separator_pos = device_name.find(':')
+                hostapi = sounddevice_soundcard.get_hostapi_by_name(
+                    device_name[0:separator_pos])
+                name = device_name[separator_pos+1:].strip()
+                for i, device_info in enumerate(sounddevice.query_devices()):
+                    if ((device_info['hostapi'] == hostapi) and
+                            (device_info['name'] == name)):
+                        return i
+            print(
+                "Warning: sounddevice Device '{}' not found"
+                .format(device_name))
+            return None
+
+        @staticmethod
+        def get_hostapi_by_name(hostapi_name):
+            hostapis = sounddevice.query_hostapis()
+            for index, host_api_info in enumerate(hostapis):
+                if host_api_info['name'] == hostapi_name:
+                    return index
+            print(
+                "Warning: sounddevice Host API '{}' not found"
+                .format(hostapi_name))
+            return None
+
+        def update(self):
+            #print("here")
+            try:
+                if self.stream.read_available == 0:
+                    return (None, None)
+                if self.format in [S16_LE, S32_LE]:
+                    self.localbuffer = numpy.append(self.localbuffer, self.stream.read(self.stream.read_available)[0].flatten())
+                #print(len(self.localbuffer))
+                if len(self.localbuffer) > self.audio_sampling_rate:
+                    oneSecondChunk = self.localbuffer[:self.audio_sampling_rate]
+                    self.localbuffer = self.localbuffer[self.audio_sampling_rate:]
+                    self.bufferStartTime += 1
+                    return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.bufferStartTime - 1)
+                else:
+                    return (None, None)
+            except sounddevice.PortAudioError as err:
+                print("Error reading device", self.name)
+                print(err)
+
+        def capture_1sec(self):
+            """
+            return one second recording as numpy array
+            after unpacking, the format is
+                for Channels = 1: [left, ..., left]
+                for Channels = 2: [left, right ..., left, right]
+
+            the returned data format is
+                for Channels = 1: [[left], ..., [left]]
+                for Channels = 2: [[left, right], ..., [left, right]]
+
+            access the left channel as unpacked_data[:, 0]
+            access the right channel as unpacked_data[:, 1]
+            """
+            unpacked_data = array([])
+            try:
+                t = time.time()
+                if self.format in [S16_LE, S32_LE]:
+                    unpacked_data = sounddevice.rec(
+                        frames=self.audio_sampling_rate,
+                        dtype=self.FORMAT_MAP[self.format],
+                        blocking=True).flatten()
+                else:
+                    # 'int24' is not supported by sounddevice.rec(),
+                    # insetad sounddevice.RawInputStream() has to be used
+                    # in combination with a callback to sonsume the data
+                    raise NotImplementedError(
+                        "'int24' is not supported by sounddevice.rec()")
+                self.duration = time.time() - t
+                assert (len(unpacked_data) ==
+                        (self.audio_sampling_rate * self.channels)), \
+                    "expected the number of samples to be identical with " \
+                    "sampling rate * number of channels"
+            except sounddevice.PortAudioError as err:
+                print("Error reading device", self.name)
+                print(err)
+            return unpacked_data.reshape((
+                self.audio_sampling_rate,
+                self.channels))
+
+        def close(self):
+            pass  # to check later if there is something to do
+
+        def info(self):
+            print(self.name, "at", self.audio_sampling_rate, "Hz")
+
+            # index 0 of sounddevice.default.device is the input device
+            assert (sounddevice.default.device[0] ==
+                    self.get_device_by_name(self.device_name)), \
+                "get_device_by_name() delivered an unexpected device"
+
+            try:
+                one_sec = self.capture_1sec()
+                text_data = ""
+                text_vector_sum = "Vector sum"
+                peak_freq = []
+                for channel in range(self.channels):
+                    channel_one_sec = one_sec[:, channel]
+                    peak_freq.append(get_peak_freq(
+                        channel_one_sec, self.audio_sampling_rate))
+                    text_data += "[{} ... {}], ".format(
+                        " ".join(str(i) for i in channel_one_sec[:5]),
+                        " ".join(str(i) for i in channel_one_sec[-5:]))
+                    text_vector_sum += " {},".format(channel_one_sec.sum())
+                print(
+                    "{:6d} "
+                    "{} "
+                    "read from {}, "
+                    "shape {}, "
+                    "format {}, "
+                    "channel {}, "
+                    "duration {:3.2f} sec, "
+                    "peak freq {} Hz"
+                    .format(
+                        len(channel_one_sec),
+                        type(channel_one_sec[0]),
+                        self.name,
+                        one_sec.shape,
+                        self.format,
+                        channel,
+                        self.duration,
+                        peak_freq))
+                print(text_data)
+                print(text_vector_sum)
+            except Exception as err:
+                print("Exception", type(err), err)
+
+except ImportError:
+    pass
+
+
+try:
+    import pyaudio  # for Linux with jackd OR windows
+    audioModule.append("pyaudio")
+
+    def pyaudio_test(device, sampling_rate, format, channels):
+        print()
+        try:
+            print(
+                "Accessing '{}' at {} Hz via pyaudio "
+                "format {}, channels {}, ..."
+                .format(device, sampling_rate, format, channels))
+            sc = pyaudio_soundcard(device, sampling_rate, format, channels)
+            sc.info()
+            return True
+        except Exception as err:
+            print(err)
+            return False
+
+    class pyaudio_soundcard():
+        # map ALSA format string to module format
+        FORMAT_MAP = {
+            # Signed 16 bit samples stored in 2 bytes, Little Endian byte order
+            S16_LE: pyaudio.paInt16,
+
+            # Signed 24 bit samples stored in 3 bytes, Little Endian byte order
+            S24_3LE: pyaudio.paInt24,
+
+            # Signed 32 bit samples stored in 4 bytes, Little Endian byte order
+            S32_LE: pyaudio.paInt32,
+        }
+
+        # map ALSAO format string to length of one sample in bytes
+        FORMAT_LENGTHS = {
+            S16_LE: 2,
+            S24_3LE: 3,
+            S32_LE: 4,
+        }
+
+        def __init__(
+                self,
+                device_name,
+                audio_sampling_rate,
+                format,
+                channels):
+            print(
+                "pyaudio device '{}', "
+                "sampling rate {}, "
+                "format {}, "
+                "channels {}"
+                .format(
+                    device_name,
+                    audio_sampling_rate,
+                    format,
+                    channels))
+
+            # time to capture 1 sec of data excluding the format conversion
+            self.duration = None
+
+            self.format = format
+            self.channels = channels
+            self.CHUNK = 1024
+            self.pa_lib = pyaudio.PyAudio()
+            self.device_name = device_name
+            self.input_device_index = self.get_device_by_name(self.device_name)
+            self.audio_sampling_rate = audio_sampling_rate
+
+            self.pa_stream = self.pa_lib.open(
+                format=self.FORMAT_MAP[self.format],
+                channels=self.channels,
+                rate=self.audio_sampling_rate,
+                input=True,
+                frames_per_buffer=self.CHUNK,
+                input_device_index=self.input_device_index)
+            self.name = "pyaudio '{}'".format(device_name)
+
+        @staticmethod
+        def query_input_devices():
+            input_device_names = []
+            for i in range(pyaudio.PyAudio().get_device_count()):
+                device_info = pyaudio.PyAudio().get_device_info_by_index(i)
+                # we are interrested only in input devices
+                if device_info['maxInputChannels'] > 0:
+                    hostapi_name = pyaudio.PyAudio() \
+                        .get_host_api_info_by_index(
+                            device_info['hostApi'])['name']
+                    input_device_names.append(
+                        "{}: {}"
+                        .format(hostapi_name, device_info['name']))
+            return input_device_names
+
+        @staticmethod
+        def get_device_by_name(device_name):
+            if str == type(device_name):
+                separator_pos = device_name.find(':')
+                hostApi = pyaudio_soundcard.get_hostapi_by_name(
+                    device_name[0:separator_pos])
+                name = device_name[separator_pos+1:].strip()
+                for i in range(pyaudio.PyAudio().get_device_count()):
+                    device_info = pyaudio.PyAudio().get_device_info_by_index(i)
+                    if ((device_info['hostApi'] == hostApi) and
+                            (device_info['name'] == name)):
+                        return i
+            print(
+                "Warning: pyaudio Device '{}' not found."
+                .format(device_name))
+            return None
+
+        @staticmethod
+        def get_hostapi_by_name(hostapi_name):
+            for i in range(pyaudio.PyAudio().get_host_api_count()):
+                host_api_info = pyaudio.PyAudio().get_host_api_info_by_index(i)
+                if host_api_info['name'] == hostapi_name:
+                    return host_api_info['index']
+            print(
+                "Warning: pyaudio Host API '{}' not found"
+                .format(hostapi_name))
+            return None
+
+        def capture_1sec(self):
+            """
+            return one second recording as numpy array
+            after unpacking, the format is
+                for Channels = 1: [left, ..., left]
+                for Channels = 2: [left, right ..., left, right]
+
+            the returned data format is
+                for Channels = 1: [[left], ..., [left]]
+                for Channels = 2: [[left, right], ..., [left, right]]
+
+            access the left channel as unpacked_data[:, 0]
+            access the right channel as unpacked_data[:, 1]
+            """
+            t = time.time()
+            raw_data = bytearray(self.capture(1))
+            self.duration = time.time() - t
+            if self.format == S16_LE:
+                unpacked_data = array(st_unpack(
+                    "<%ih" % (self.audio_sampling_rate * self.channels),
+                    raw_data))
+                return unpacked_data.reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            elif self.format == S24_3LE:
+                unpacked_data = []
+                for i in range(self.audio_sampling_rate * self.channels):
+                    chunk = raw_data[i*3:i*3+3]
+                    unpacked_data.append(st_unpack(
+                        '<i',
+                        chunk + (b'\0' if chunk[2] < 128 else b'\xff'))[0])
+                return array(unpacked_data).reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            elif self.format == S32_LE:
+                unpacked_data = array(st_unpack(
+                    "<%ii" % (self.audio_sampling_rate * self.channels),
+                    raw_data))
+                return unpacked_data.reshape((
+                    self.audio_sampling_rate,
+                    self.channels))
+            else:
+                raise NotImplementedError(
+                    "Format conversion for '{}' is not yet implemented!"
+                    .format(self.format))
+
+        def capture(self, secs):
+            frames = []
+            expected_number_of_bytes = self.FORMAT_LENGTHS[self.format] \
+                * self.audio_sampling_rate \
+                * self.channels \
+                * secs
+            while len(frames) < expected_number_of_bytes:
+                try:
+                    # TODO: investigate exception_on_overflow=True
+                    # ignoring overflows seems not to be the best idea
+                    data = self.pa_stream.read(
+                        self.CHUNK,
+                        exception_on_overflow=False)
+                    frames.extend(data)
+                except IOError as err:
+                    print("IOError reading device:", str(err))
+                    if -9981 == err.errno:
+                        # -9981 is input overflow. This should not happen
+                        # with exception_on_overflow=False
+                        pass
+                    else:
+                        break   # avoid an endless loop, i.e. with error -9988
+            return frames[:expected_number_of_bytes]
+
+        def close(self):
+            self.pa_stream.stop_stream()
+            self.pa_stream.close()
+            self.pa_lib.terminate()
+
+        def info(self):
+            print(self.name, "at", self.audio_sampling_rate, "Hz")
+            try:
+                one_sec = self.capture_1sec()
+                text_data = ""
+                text_vector_sum = "Vector sum"
+                peak_freq = []
+                for channel in range(self.channels):
+                    channel_one_sec = one_sec[:, channel]
+                    peak_freq.append(get_peak_freq(
+                        channel_one_sec,
+                        self.audio_sampling_rate))
+                    text_data += "[{} ... {}], ".format(
+                        " ".join(str(i) for i in channel_one_sec[:5]),
+                        " ".join(str(i) for i in channel_one_sec[-5:]))
+                    text_vector_sum += " {},".format(channel_one_sec.sum())
+                print(
+                    "{:6d} "
+                    "{} "
+                    "read from {}, "
+                    "shape {}, "
+                    "format {}, "
+                    "channel {}, "
+                    "duration {:3.2f} sec, "
+                    "peak freq {} Hz"
+                    .format(
+                        len(channel_one_sec),
+                        type(channel_one_sec[0]),
+                        self.name,
+                        one_sec.shape,
+                        self.format,
+                        channel,
+                        self.duration,
+                        peak_freq))
+                print(text_data)
+                print(text_vector_sum)
+            except Exception as err:
+                print("Exception", type(err), err)
+
+except ImportError:
+    pass
+
+
+class GaplessSampler():
+    """Sampler will gather sound capture from various devices."""
+
+    def __init__(self, controller, audio_sampling_rate=96000, NFFT=None):
+        self.version = "1.4 20160207"
+        self.controller = controller
+        self.scaling_factor = controller.config['scaling_factor']
+
+        self.audio_sampling_rate = audio_sampling_rate
+        if NFFT is not None:
+            self.NFFT = NFFT
+        else:
+            # NFFT = 1024 for 44100 and 48000,
+            #        2048 for 96000,
+            #        4096 for 192000
+            # -> the frequency resolution is constant
+            self.NFFT = max(1024, 1024 * self.audio_sampling_rate // 48000)
+        self.sampler_ok = True
+
+        try:
+            if controller.config['Audio'] == 'alsaaudio':
+                self.capture_device = alsaaudio_soundcard(
+                    controller.config['Card'],  # deprecated
+                    controller.config['Device'],
+                    audio_sampling_rate,
+                    controller.config['Format'],
+                    controller.config['Channels'],
+                    controller.config['PeriodSize'])
+            elif controller.config['Audio'] == 'sounddevice':
+                self.capture_device = sounddevice_soundcard(
+                    controller.config['Device'],
+                    audio_sampling_rate,
+                    controller.config['Format'],
+                    controller.config['Channels'])
+            elif controller.config['Audio'] == 'pyaudio':
+                self.capture_device = pyaudio_soundcard(
+                    controller.config['Device'],
+                    audio_sampling_rate,
+                    controller.config['Format'],
+                    controller.config['Channels'])
+            else:
+                self.display_error_message(
+                    "Unknown audio module:" + controller.config['Audio'])
+                self.sampler_ok = False
+        except Exception as err:
+            self.sampler_ok = False
+            self.display_error_message(
+                "Could not open capture device. "
+                "Please check your .cfg file or hardware.")
+            print("Error", controller.config['Audio'])
+            print(err)
+            print(traceback.format_exc())
+
+        if self.sampler_ok:
+            print("-", self.capture_device.name)
+
+    def set_monitored_frequencies(self, stations):
+        self.monitored_channels = []
+        self.monitored_bins = []
+        for station in stations:
+            self.monitored_channels.append(station['channel'])
+            binSample = int(((int(station['frequency'])
+                              * self.NFFT) / self.audio_sampling_rate))
+            self.monitored_bins.append(binSample)
+            # print ("monitored freq =", station[FREQUENCY],
+            # " => bin = ", binSample)
+
+    def update(self):
+        try:
+            return self.capture_device.update()
+        except Exception as err:
+            self.sampler_ok = False
+            print(
+                "Fail to read data from audio using "
+                + self.capture_device.name)
+            
+            print(err)
+
+    def capture_1sec(self):
+        """Capture 1 second of data, returned data as an array
+        """
+        try:
+            self.data = self.capture_device.capture_1sec()
+        except Exception:
+            self.sampler_ok = False
+            print(
+                "Fail to read data from audio using "
+                + self.capture_device.name)
+            self.data = []
+        else:
+            # Scale A/D raw_data to voltage here
+            # Might substract 5v to make the data look more like SID
+            if(self.scaling_factor != 1.0):
+                self.data = self.data * self.scaling_factor
+
+        return self.data
+
+    def close(self):
+        if "capture_device" in dir(self):
+            self.capture_device.close()
+
+    def display_error_message(self, message):
+        msg = "From Sampler object instance:\n" + message + ". Please check.\n"
+        self.controller.viewer.status_display(msg)
+
+
+def doTest(args, device, sampling_rate, format):
+    if (args.device is None) or (args.device == device):
+        if ((args.sampling_rate is None) or
+                (args.sampling_rate == sampling_rate)):
+            if (args.format is None) or (args.format == format):
+                return True
+    return False
+
+
+if __name__ == '__main__':
+    SAMPLING_RATES = [44100, 48000, 96000, 192000]
+    FORMATS = [S16_LE, S24_3LE, S32_LE]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-l", "--list",
+        help="list the potential module and device combinations and exit",
+        action='store_true')
+    parser.add_argument(
+        "-m", "--module",
+        help="audio module",
+        choices=audioModule,
+        default=None)
+    parser.add_argument(
+        "-d", "--device",
+        help="fully qualified device name",
+        default=None)
+    parser.add_argument(
+        "-s", "--sampling-rate",
+        help="sampling rate",
+        choices=SAMPLING_RATES,
+        type=int,
+        default=None)
+    parser.add_argument(
+        "-f", "--format",
+        help="format to be captured",
+        choices=FORMATS,
+        default=None)
+    parser.add_argument(
+        "-p", "--periodsize",
+        help="""periodsize parameter of the PCM interface
+default=1024, if the computer runs out of memory,
+select smaller numbers like 128, 256, 512, ...""",
+        type=int,
+        default=1024)
+    parser.add_argument(
+        "-n", "--channels",
+        help="number of channels, default=1",
+        choices=[1, 2],
+        type=int,
+        default=1)
+    args = parser.parse_args()
+
+    # -l/--list is an exclusive parameter, exit after execution
+    if args.list:
+        if 'alsaaudio' in audioModule:
+            devices = alsaaudio.pcms()
+            for device in devices:
+                print('--module=alsaaudio --device="{}"'.format(device))
+            print()
+        if 'sounddevice' in audioModule:
+            devices = sounddevice_soundcard.query_input_devices()
+            for device in devices:
+                print('--module=sounddevice --device="{}"'.format(device))
+            print()
+        if 'pyaudio' in audioModule:
+            devices = pyaudio_soundcard.query_input_devices()
+            for device in devices:
+                print('--module=pyaudio --device="{}"'.format(device))
+            print()
+        sys.exit(0)
+
+    if (args.module is None) or (args.module == 'alsaaudio'):
+        if 'alsaaudio' in audioModule:
+            devices = alsaaudio.pcms()
+            for device in devices:
+                for sampling_rate in SAMPLING_RATES:
+                    for format in FORMATS:
+                        if doTest(args, device, sampling_rate, format):
+                            alsaaudio_test(
+                                device,
+                                sampling_rate,
+                                format,
+                                args.channels,
+                                args.periodsize)
+        else:
+            print("not installed.")
+
+    if (args.module is None) or (args.module == 'sounddevice'):
+        if 'sounddevice' in audioModule:
+            devices = sounddevice_soundcard.query_input_devices()
+            for device in devices:
+                for sampling_rate in SAMPLING_RATES:
+                    for format in FORMATS:
+                        if doTest(args, device, sampling_rate, format):
+                            sounddevice_test(
+                                device,
+                                sampling_rate,
+                                format,
+                                args.channels)
+        else:
+            print("not installed.")
+
+    if (args.module is None) or (args.module == 'pyaudio'):
+        if 'pyaudio' in audioModule:
+            devices = pyaudio_soundcard.query_input_devices()
+            for device in devices:
+                for sampling_rate in SAMPLING_RATES:
+                    for format in FORMATS:
+                        if doTest(args, device, sampling_rate, format):
+                            pyaudio_test(
+                                device,
+                                sampling_rate,
+                                format,
+                                args.channels)
+        else:
+            print("not installed.")

--- a/supersid/gapless_sampler.py
+++ b/supersid/gapless_sampler.py
@@ -171,10 +171,10 @@ try:
                                          device=device)
             
             
-            self.bufferStartTime = time.time()
+            self.audioTime = time.time()
             self.localbuffer = array([])
 
-            timepast5sec = (datetime.datetime.fromtimestamp(self.bufferStartTime).second + datetime.datetime.fromtimestamp(self.bufferStartTime).microsecond / 1000000) % 5
+            timepast5sec = (datetime.datetime.fromtimestamp(self.audioTime).second + datetime.datetime.fromtimestamp(self.audioTime).microsecond / 1000000) % 5
             dropsamples = (5 - timepast5sec) * self.audio_sampling_rate
 
             while(len(self.localbuffer) < (dropsamples * self.channels)):
@@ -197,7 +197,7 @@ try:
                         raw_data))
                 self.localbuffer = numpy.append(self.localbuffer, unpacked_data)
             self.localbuffer = self.localbuffer[(dropsamples * self.channels):]
-            self.bufferStartTime = self.bufferStartTime + dropsamples / self.audio_sampling_rate
+            self.audioTime = self.audioTime + dropsamples / self.audio_sampling_rate
                 
         def update(self):
             #print("here")
@@ -228,8 +228,8 @@ try:
             if len(self.localbuffer) > self.audio_sampling_rate * self.channels:
                 oneSecondChunk = self.localbuffer[:(self.audio_sampling_rate * self.channels)]
                 self.localbuffer = self.localbuffer[(self.audio_sampling_rate * self.channels):]
-                self.bufferStartTime += 1
-                return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.bufferStartTime)
+                self.audioTime += 1
+                return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.audioTime)
             else:
                 return (None, None)
             
@@ -345,18 +345,18 @@ try:
             self.localbuffer = array([])
             self.stream = sounddevice.InputStream()
             self.stream.start()
-            self.bufferStartTime = time.time()
+            self.audioTime = time.time()
             
             #Drop a number of samples in order to get to the next 5 second interval.
             #print("Audio Stream started at:")
             #print(datetime.datetime.fromtimestamp(self.bufferStartTime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f"))
-            timepast5sec = (datetime.datetime.fromtimestamp(self.bufferStartTime).second + datetime.datetime.fromtimestamp(self.bufferStartTime).microsecond / 1000000) % 5
+            timepast5sec = (datetime.datetime.fromtimestamp(self.audioTime).second + datetime.datetime.fromtimestamp(self.audioTime).microsecond / 1000000) % 5
             #print(timepast5sec)
             dropsamples = (5 - timepast5sec) * self.audio_sampling_rate
             #print("Drop samples:")
             #print(int(dropsamples))
             self.stream.read(int(dropsamples))
-            self.bufferStartTime = self.bufferStartTime + dropsamples / self.audio_sampling_rate
+            self.audioTime = self.audioTime + dropsamples / self.audio_sampling_rate
             #print("Seconds: ")
             #print(dropsamples / self.audio_sampling_rate)
             #print("Buffer now at:")
@@ -419,8 +419,8 @@ try:
                 if len(self.localbuffer) > self.audio_sampling_rate * self.channels:
                     oneSecondChunk = self.localbuffer[:(self.audio_sampling_rate * self.channels)]
                     self.localbuffer = self.localbuffer[(self.audio_sampling_rate * self.channels):]
-                    self.bufferStartTime += 1
-                    return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.bufferStartTime)
+                    self.audioTime += 1
+                    return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.audioTime)
                 else:
                     return (None, None)
             except sounddevice.PortAudioError as err:
@@ -554,12 +554,12 @@ try:
                 frames_per_buffer=self.CHUNK,
                 input_device_index=self.input_device_index)
             self.pa_stream.start_stream()
-            self.bufferStartTime = time.time()
+            self.audioTime = time.time()
             
-            timepast5sec = (datetime.datetime.fromtimestamp(self.bufferStartTime).second + datetime.datetime.fromtimestamp(self.bufferStartTime).microsecond / 1000000) % 5
+            timepast5sec = (datetime.datetime.fromtimestamp(self.audioTime).second + datetime.datetime.fromtimestamp(self.audioTime).microsecond / 1000000) % 5
             dropsamples = (5 - timepast5sec) * self.audio_sampling_rate
             self.pa_stream.read(int(dropsamples), exception_on_overflow=True)
-            self.bufferStartTime = self.bufferStartTime + dropsamples / self.audio_sampling_rate
+            self.audioTime = self.audioTime + dropsamples / self.audio_sampling_rate
             
         def update(self):
             #print("here")
@@ -589,8 +589,8 @@ try:
                 if len(self.localbuffer) > self.audio_sampling_rate * self.channels:
                     oneSecondChunk = self.localbuffer[:(self.audio_sampling_rate * self.channels)]
                     self.localbuffer = self.localbuffer[(self.audio_sampling_rate * self.channels):]
-                    self.bufferStartTime += 1
-                    return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.bufferStartTime)
+                    self.audioTime += 1
+                    return (oneSecondChunk.reshape(self.audio_sampling_rate, self.channels), self.audioTime)
                 else:
                     return (None, None)
             except Exception as err:

--- a/supersid/sampler.py
+++ b/supersid/sampler.py
@@ -325,7 +325,7 @@ try:
                 self.device_name)
             sounddevice.default.channels = self.channels
             sounddevice.default.latency = 'low'
-            sounddevice.default.dtype = 'int16'
+            sounddevice.default.dtype = self.FORMAT_MAP[format]
             self.name = "sounddevice '{}'".format(self.device_name)
 
         @staticmethod

--- a/supersid/supersid.py
+++ b/supersid/supersid.py
@@ -144,7 +144,7 @@ class SuperSID():
         self.stop_timer = False
         # Create Timer
         if self.config['sampler'] == 'gapless':
-            self.timer = threading.Timer(0.01, self.gapless_timer)
+            self.timer = threading.Timer(0.1, self.gapless_timer)
             self.timer.start()
         elif self.config['sampler'] == 'normal':
             self.timer = SidTimer(self.config['log_interval'], self.on_timer)
@@ -329,7 +329,7 @@ class SuperSID():
 
 
         if not self.stop_timer:
-            self.timer = threading.Timer(0.05, self.gapless_timer)
+            self.timer = threading.Timer(0.1, self.gapless_timer)
             self.timer.start()
 
     def on_timer(self):

--- a/supersid/supersid.py
+++ b/supersid/supersid.py
@@ -192,8 +192,8 @@ class SuperSID():
                                 self.sampler.monitored_bins):
                             average = 0
                             for second in self.signal_strength_average:
-                                average = second[channel][binSample]
-                            signal_strengths.append(average)
+                                average += second[channel][binSample]
+                            signal_strengths.append(average / 5)
                         self.signal_strength_average = array([])
         except IndexError as idxerr:
             print("Index Error:", idxerr)

--- a/supersid/supersid.py
+++ b/supersid/supersid.py
@@ -188,6 +188,17 @@ class SuperSID():
                 audioTime = audioTime + self.audioDriftCorrection
                 systemTime = time.time()
                 audioDrift = systemTime - audioTime
+
+                # If the audio drift is more than 5 seconds, there was a big interrupt
+                # skip the entire missing log intervals until the audio clock is within
+                # 5 seconds of the system clock.
+                while audioDrift > 5:
+                    self.audioDriftCorrection += 5
+                    audioTime += 5
+                    audioDrift -= 5
+
+                # If the drift is less than 5 seconds, then add or remove one FFT
+                # from the average to bring the audio clock towards the system clock.
                 if self.averageSize == 5:
                     if audioDrift >= 1:
                         self.audioDriftCorrection += 1

--- a/supersid/supersid.py
+++ b/supersid/supersid.py
@@ -22,6 +22,7 @@ import subprocess
 import threading
 import numpy
 import time
+import traceback
 from datetime import datetime, timezone
 
 # SuperSID Package classes
@@ -49,7 +50,6 @@ class SuperSID():
         self.viewer = None
 
         
-        self.signal_strength_average = array([])
         self.audioDriftCorrection = 0
         self.averageSize = 5
 
@@ -59,6 +59,7 @@ class SuperSID():
         if viewer is not None:
             self.config['viewer'] = viewer
 
+        self.sample_buffer = array([])
         # command line parameter -r/--read has precedence over automatic read
         if read_file is None:
             # if there are hourly saves ...
@@ -174,7 +175,6 @@ class SuperSID():
 
     def gapless_timer(self):
         signal_strengths = []
-        gotNewData = False
         audioTime = None
         systemTime = None
         try:
@@ -184,6 +184,12 @@ class SuperSID():
             (data, audioTime) = self.sampler.update()
 
             if self.sampler.sampler_ok and data is not None:
+
+
+                # append the data to the sample buffer
+                self.sample_buffer = numpy.append(self.sample_buffer, data)
+                #print(len(self.sample_buffer))
+                
                 #Setup any audio clock drift corrections.
                 audioTime = audioTime + self.audioDriftCorrection
                 systemTime = time.time()
@@ -197,82 +203,86 @@ class SuperSID():
                     audioTime += 5
                     audioDrift -= 5
 
-                # If the drift is less than 5 seconds, then add or remove one FFT
-                # from the average to bring the audio clock towards the system clock.
-                if self.averageSize == 5:
-                    if audioDrift >= 1:
-                        self.audioDriftCorrection += 1
-                        self.averageSize = 4
-                    if audioDrift <= -1:
-                        self.audioDriftCorrection -= 1
-                        self.averageSize = 6
+                # Assume the audio time is the correct time for the last sample recieved
+                # determine what the sample for the next log interval is.
 
-                Pxx, freqs = self.psd(data, self.sampler.NFFT,
-                                      self.sampler.audio_sampling_rate)
-                if Pxx is not None:
-                    self.signal_strength_average = numpy.append(self.signal_strength_average, Pxx)
-                    #print(len(self.signal_strength_average))
+                last_sample_second = (datetime.fromtimestamp(audioTime, tz=timezone.utc).hour * 60 * 60
+                                    + datetime.fromtimestamp(audioTime, tz=timezone.utc).minute * 60
+                                    + datetime.fromtimestamp(audioTime, tz=timezone.utc).second
+                                    + datetime.fromtimestamp(audioTime, tz=timezone.utc).microsecond / 1000000)
+                
+                first_sample_second = last_sample_second - len(self.sample_buffer) / self.sampler.audio_sampling_rate
+                seconds_to_next_log = self.config['log_interval'] - first_sample_second % self.config['log_interval']
+                if seconds_to_next_log == 0:
+                    seconds_to_next_log = self.config['log_interval']
+                #print("Seconds to next log: %f" % seconds_to_next_log)
 
-                    if len(self.signal_strength_average) >= self.averageSize:
-                        gotNewData = True
+                samples_to_next_log = int(seconds_to_next_log * self.sampler.audio_sampling_rate) + 1
+                #print("Samples to next log: %d" % samples_to_next_log)
+
+                samples_needed = int(samples_to_next_log - len(self.sample_buffer))
+                #print("Samples Needed: %d" % samples_needed)
+
+                if samples_needed <= 0:
+                    log_samples = self.sample_buffer[:samples_to_next_log]
+                    #print(log_samples.shape)
+                    self.sample_buffer = self.sample_buffer[samples_to_next_log:]
+
+                    Pxx, freqs = self.psd(log_samples.reshape(len(log_samples), data.shape[1]), self.sampler.NFFT,
+                                        self.sampler.audio_sampling_rate)
+                    if Pxx is not None:
                         for channel, binSample in zip(
                                 self.sampler.monitored_channels,
                                 self.sampler.monitored_bins):
-                            average = 0
-                            for second in self.signal_strength_average[:self.averageSize]:
-                                average += second[channel][binSample]
-                            signal_strengths.append(average / self.averageSize)
+                            signal_strengths.append(Pxx[channel][binSample])
+                        # in case of an exception,
+                        # signal_strengths may not have the expected length
+                    while len(signal_strengths) < len(self.sampler.monitored_bins):
+                        signal_strengths.append(0.0)
+                    # do we need to save some files (hourly) or switch to a new day?
+                    if ((datetime.fromtimestamp(audioTime).minute == 0) and
+                            (datetime.fromtimestamp(audioTime).second < self.config['log_interval'])):
+                        if self.config['hourly_save'] == 'YES':
+                            fileName = "hourly_current_buffers.raw.ext.%s.csv" % (
+                                self.logger.sid_file.sid_params['utc_starttime'][:10])
+                            self.save_current_buffers(filename=fileName,
+                                            log_type='raw',
+                                            log_format='supersid_extended')
+                        # a new day!
+                        if datetime.fromtimestamp(audioTime).hour == 0:
+                            # use log_type and log_format requested by the user
+                            # in the .cfg
+                            self.save_current_buffers(log_type=self.config['log_type'],
+                                                    log_format=self.config['log_format'])
+                            self.clear_all_data_buffers()
+                            self.ftp_to_stanford()
+                    # Save signal strengths into memory buffers
+                    # prepare message for status bar
+                    current_index = int((datetime.fromtimestamp(audioTime, tz=timezone.utc).hour
+                                        * 3600
+                                        + datetime.fromtimestamp(audioTime, tz=timezone.utc).minute
+                                        * 60 + datetime.fromtimestamp(audioTime, tz=timezone.utc).second) / self.config['log_interval'])
 
-                        #Preserve the next second if this is the 5th sample, and the audio drift just rose above 1
-                        self.signal_strength_average = self.signal_strength_average[self.averageSize:]
-                        
-                        # If a sample was added or removed, reset the average size now.
-                        self.averageSize = 5
+                    message = datetime.fromtimestamp(audioTime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S") + " Drift: " + "{:.3f}".format(audioDrift) + "(%d)" % self.audioDriftCorrection + "  [%d]  " % current_index
+                    for station, strength in zip(self.config.stations,
+                                                signal_strengths):
+                        station['raw_buffer'][current_index] = strength
+                        message += station['call_sign'] + "=%f " % strength
+                    self.logger.sid_file.timestamp[current_index] = datetime.fromtimestamp(audioTime, tz=timezone.utc)
+
+                    # end of this thread/need to handle to View to display
+                    # captured data & message
+                    self.viewer.status_display(message, level=2)
+
+
         except IndexError as idxerr:
             print("Index Error:", idxerr)
             print("Data len:", len(data))
+            tb = traceback.extract_tb(idxerr.__traceback__)
+            print(tb)
         except TypeError as err_te:
             print("Warning:", err_te)
 
-        if gotNewData:
-            # in case of an exception,
-            # signal_strengths may not have the expected length
-            while len(signal_strengths) < len(self.sampler.monitored_bins):
-                signal_strengths.append(0.0)
-            # do we need to save some files (hourly) or switch to a new day?
-            if ((datetime.fromtimestamp(audioTime).minute == 0) and
-                    (datetime.fromtimestamp(audioTime).second < self.config['log_interval'])):
-                if self.config['hourly_save'] == 'YES':
-                    fileName = "hourly_current_buffers.raw.ext.%s.csv" % (
-                        self.logger.sid_file.sid_params['utc_starttime'][:10])
-                    self.save_current_buffers(filename=fileName,
-                                            log_type='raw',
-                                            log_format='supersid_extended')
-                # a new day!
-                if datetime.fromtimestamp(audioTime).hour == 0:
-                    # use log_type and log_format requested by the user
-                    # in the .cfg
-                    self.save_current_buffers(log_type=self.config['log_type'],
-                                            log_format=self.config['log_format'])
-                    self.clear_all_data_buffers()
-                    self.ftp_to_stanford()
-            # Save signal strengths into memory buffers
-            # prepare message for status bar
-            current_index = int((datetime.fromtimestamp(audioTime, tz=timezone.utc).hour
-                                   * 3600
-                                   + datetime.fromtimestamp(audioTime, tz=timezone.utc).minute
-                                   * 60 + datetime.fromtimestamp(audioTime, tz=timezone.utc).second) / self.config['log_interval'])
-
-            message = datetime.fromtimestamp(audioTime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S") + " Drift: " + "{:.3f}".format(audioDrift) + "(%d)" % self.audioDriftCorrection + "  [%d]  " % current_index
-            for station, strength in zip(self.config.stations,
-                                        signal_strengths):
-                station['raw_buffer'][current_index] = strength
-                message += station['call_sign'] + "=%f " % strength
-            self.logger.sid_file.timestamp[current_index] = datetime.fromtimestamp(audioTime, tz=timezone.utc)
-
-            # end of this thread/need to handle to View to display
-            # captured data & message
-            self.viewer.status_display(message, level=2)
 
         if not self.stop_timer:
             self.timer = threading.Timer(0.05, self.gapless_timer)

--- a/supersid/supersid.py
+++ b/supersid/supersid.py
@@ -230,7 +230,7 @@ class SuperSID():
                                    + datetime.fromtimestamp(audioTime, tz=timezone.utc).minute
                                    * 60 + datetime.fromtimestamp(audioTime, tz=timezone.utc).second) / self.config['log_interval'])
 
-            message = datetime.fromtimestamp(audioTime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S") + " Drift: " + "{:.3f}".format(time.time() - audioTime - 1) + "  [%d]  " % current_index
+            message = datetime.fromtimestamp(audioTime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S") + " Drift: " + "{:.3f}".format(time.time() - audioTime) + "  [%d]  " % current_index
             for station, strength in zip(self.config.stations,
                                         signal_strengths):
                 station['raw_buffer'][current_index] = strength

--- a/supersid/textsidviewer.py
+++ b/supersid/textsidviewer.py
@@ -46,9 +46,12 @@ class textSidViewer:
         """Call 'psd', calculates the spectrum."""
         try:
             Pxx = {}
+            overlap = 0
+            if self.controller.config['overlap']:
+                overlap = int(NFFT / 2)
             for channel in range(self.controller.config['Channels']):
                 Pxx[channel], freqs = \
-                    mlab_psd(data[:, channel], NFFT=NFFT, Fs=FS, noverlap=int(NFFT / 2))
+                    mlab_psd(data[:, channel], NFFT=NFFT, Fs=FS, noverlap=overlap)
         except RuntimeError as err_re:
             print("Warning:", err_re)
             Pxx, freqs = None, None

--- a/supersid/textsidviewer.py
+++ b/supersid/textsidviewer.py
@@ -48,7 +48,7 @@ class textSidViewer:
             Pxx = {}
             for channel in range(self.controller.config['Channels']):
                 Pxx[channel], freqs = \
-                    mlab_psd(data[:, channel], NFFT=NFFT, Fs=FS)
+                    mlab_psd(data[:, channel], NFFT=NFFT, Fs=FS, noverlap=int(NFFT / 2))
         except RuntimeError as err_re:
             print("Warning:", err_re)
             Pxx, freqs = None, None

--- a/supersid/tksidviewer.py
+++ b/supersid/tksidviewer.py
@@ -236,7 +236,7 @@ class tkSidViewer():
             Pxx = {}
             for channel in range(self.controller.config['Channels']):
                 Pxx[channel], freqs = self.psd_axes.psd(
-                    data[:, channel], NFFT=NFFT, Fs=FS)
+                    data[:, channel], NFFT=NFFT, Fs=FS, noverlap=int(NFFT / 2))
 
                 if self.controller.config['waterfall_samples']:
                     pxx = np.log10(Pxx[channel][:-1].reshape(

--- a/supersid/tksidviewer.py
+++ b/supersid/tksidviewer.py
@@ -295,7 +295,7 @@ class tkSidViewer():
                 self.need_refresh = False
             except IndexError as err_idx:
                 print("Warning:", err_idx)
-        self.tk_root.after(100, self.refresh_psd)
+        self.tk_root.after(250, self.refresh_psd)
 
     def save_file(self, param=None):
         """Save the files as per user's menu choice."""

--- a/supersid/tksidviewer.py
+++ b/supersid/tksidviewer.py
@@ -234,9 +234,12 @@ class tkSidViewer():
             for ax in self.figure.axes:
                 ax.clear()
             Pxx = {}
+            overlap = 0
+            if self.controller.config['overlap']:
+                overlap = int(NFFT / 2)
             for channel in range(self.controller.config['Channels']):
                 Pxx[channel], freqs = self.psd_axes.psd(
-                    data[:, channel], NFFT=NFFT, Fs=FS, noverlap=int(NFFT / 2))
+                    data[:, channel], NFFT=NFFT, Fs=FS, noverlap=overlap)
 
                 if self.controller.config['waterfall_samples']:
                     pxx = np.log10(Pxx[channel][:-1].reshape(

--- a/supersid/tksidviewer.py
+++ b/supersid/tksidviewer.py
@@ -295,7 +295,7 @@ class tkSidViewer():
                 self.need_refresh = False
             except IndexError as err_idx:
                 print("Warning:", err_idx)
-        self.tk_root.after(2000, self.refresh_psd)
+        self.tk_root.after(100, self.refresh_psd)
 
     def save_file(self, param=None):
         """Save the files as per user's menu choice."""

--- a/supersid/tksidviewer.py
+++ b/supersid/tksidviewer.py
@@ -295,7 +295,7 @@ class tkSidViewer():
                 self.need_refresh = False
             except IndexError as err_idx:
                 print("Warning:", err_idx)
-        self.tk_root.after(250, self.refresh_psd)
+        self.tk_root.after(1000, self.refresh_psd)
 
     def save_file(self, param=None):
         """Save the files as per user's menu choice."""


### PR DESCRIPTION
This change adds an alternative audio sampler that continuously records audio, and uses the audio samples from an entire log period to provide a lower variance frequency spectrum. Additionally it includes a configuration option to enable a 50% overlap for matplot's FFT slices, which allows samples that would otherwise be suppressed by the default FFT window to contribute to the estimate.

Timing is also handled by counting the audio samples received since the audio stream was opened. The relative timing of each audio sample can be known by the audio sample rate it is recorded at, even if it is not immediately received and processed by the program. This makes it more resilient to latency. Any difference between the audio clock and the system clock is averaged out over the long term and corrected by adding or removing extra audio samples from each log interval in order to reduce the drift.