### PR TITLE
sberl/107: checking for realtime violation in SidTimer._ontimer() - not the solution but additoinal information

### DIFF
--- a/supersid/sidtimer.py
+++ b/supersid/sidtimer.py
@@ -16,14 +16,14 @@ import threading
 class SidTimer:
     """Keep track of time."""
 
-    def __init__(self, interval, callback, delay=0):
+    def __init__(self, interval, callback):
         """Synchronize the timer and start the trigger mechanism.
 
         Public properties:
         - start_time: reference starting time.time() in local time
             *on the interval* (synchro)
         - expected_time: theoretical time the trigger should happen
-            as 'start_time + X * interval'
+            as 'start_time synchronized to a multiple of interval'
         - time_now: real time.time() when the trigger happened
         """
         self.version = "1.3.1 20130907"
@@ -42,7 +42,7 @@ class SidTimer:
             now = time.gmtime()
         #  request a Timer
         self.start_time = int(time.time() / self.interval) \
-            * self.interval + delay
+            * self.interval
         self.expected_time = self.start_time + self.interval
         self._timer = threading.Timer(self.expected_time - time.time(),
                                       self._ontimer)
@@ -53,6 +53,11 @@ class SidTimer:
 
         with adjustment if necessary
         i.e. running late/fast then perform callback
+
+        If _ontimer() triggers before expected_time or after expected_time_max,
+        this is an error that can cause the hourly save to be missed. Even worse
+        the creation of a new day could be missed. Let's create a warning on the
+        console if an issue with the timer reliabilitry is identified.
         """
         with self.lock:     # only one timer callback at a time
             self.time_now = time.time()
@@ -65,6 +70,14 @@ class SidTimer:
                                    * 3600
                                    + self.utc_now.minute
                                    * 60 + self.utc_now.second) / self.interval)
+
+            expected_time_max = self.expected_time + self.interval
+            if (self.time_now < self.expected_time) or (self.time_now >= expected_time_max):
+                print("WARNING: Hard realtime violation in SidTimer._ontimer(). "
+                      f"expected: [{self.expected_time}..{expected_time_max}) "
+                      f"found: {self.time_now}. "
+                      "Please report at 'https://github.com/sberl/supersid/issues/107'. ")
+
             self.expected_time += self.interval
             # callback to perform tasks
             self.callback()
@@ -80,7 +93,8 @@ class SidTimer:
 
 if __name__ == '__main__':
     TIME_INTERVAL = 5.0  # seconds
-    TEST_LENGTH = 3600.0  # seconds
+    TEST_LENGTH = 90.0  # seconds
+    FORCE_ERROR = True
 
     class TestSidTimerSubclass(SidTimer):
         """Example of SidTimer implementation.
@@ -89,7 +103,7 @@ if __name__ == '__main__':
         """
 
         def __init__(self, interval):
-            print("Waiting for synchro...", end='')
+            print("Waiting for synchronization ... ", end='')
             SidTimer.__init__(self, interval, self.on_timer_event)
             print("done.")
             self.max_plus_error, self.max_minus_error = 0, 0
@@ -100,7 +114,7 @@ if __name__ == '__main__':
             In this test class, only display some tracking on the
             timer's accuracy.
             """
-            time_error = self.expected_time - self.time_now - self.interval
+            time_error = self.time_now - (self.expected_time - self.interval)
             if time_error > 0 and time_error > self.max_plus_error:
                 self.max_plus_error = time_error
             elif time_error < 0 and time_error < self.max_minus_error:
@@ -109,7 +123,15 @@ if __name__ == '__main__':
             print("Idx", self.data_index, "now:", self.time_now,
                   "expect_time:", self.expected_time - self.interval)
             print(" err:", time_error,
-                  "interval: %f" % (self.expected_time - self.time_now))
+                  f"interval: {self.expected_time - self.time_now}",
+                  datetime.now(timezone.utc))
+            if FORCE_ERROR and ((self.time_now % 60) >= (60 - TIME_INTERVAL)):
+                # will trigger at hh:mm:55
+                # and cause hh:mm:00 .. hh:mm:04.9999 to be missed
+                print(f"FORCE_ERROR: sleeping {2 * TIME_INTERVAL} seconds at "
+                      f"{self.time_now} ...")
+                time.sleep(2 * TIME_INTERVAL)
+                print(f"FORCE_ERROR: ... wakeup at {time.time()}")
 
         def cancel_timer(self):
             """ Cancel the timer. """
@@ -122,7 +144,7 @@ if __name__ == '__main__':
         """
 
         def __init__(self, interval):
-            print("Waiting for synchro...", end='')
+            print("Waiting for synchronization ... ", end='')
             self.sid_timer = SidTimer(interval, self.on_timer_event)
             print("done.")
             self.max_plus_error, self.max_minus_error = 0, 0
@@ -130,10 +152,11 @@ if __name__ == '__main__':
         def on_timer_event(self):
             """Call back function to do tasks when Timer is triggered.
 
-            In this test , only display some tracking on the timer's accuracy
+            In this test class, only display some tracking on the
+            timer's accuracy.
             """
-            time_error = self.sid_timer.expected_time \
-                - self.sid_timer.time_now - self.sid_timer.interval
+            time_error = self.sid_timer.time_now - \
+                (self.sid_timer.expected_time - self.sid_timer.interval)
             if time_error > 0 and time_error > self.max_plus_error:
                 self.max_plus_error = time_error
             elif time_error < 0 and time_error < self.max_minus_error:
@@ -143,16 +166,25 @@ if __name__ == '__main__':
                   self.sid_timer.time_now, "expect_time:",
                   self.sid_timer.expected_time - self.sid_timer.interval)
             print(" err:", time_error,
-                  "interval: %f" % (self.sid_timer.expected_time
-                                  - self.sid_timer.time_now))
+                  f"interval: {self.sid_timer.expected_time - self.sid_timer.time_now}",
+                  datetime.now(timezone.utc))
+            if FORCE_ERROR and ((self.sid_timer.time_now % 60) >= (60 - TIME_INTERVAL)):
+                # will trigger at hh:mm:55
+                # and cause hh:mm:00 .. hh:mm:04.9999 to be missed
+                print(f"FORCE_ERROR: sleeping {2 * TIME_INTERVAL} seconds at "
+                      f"{self.sid_timer.time_now} ...")
+                time.sleep(2 * TIME_INTERVAL)
+                print(f"FORCE_ERROR: ... wakeup at {time.time()}")
 
         def cancel_timer(self):
-            """Cancel the timer."""
+            """ Cancel the timer. """
             self.sid_timer.stop()
 
 # ------------------------------------------------------------------------
-    # choose either 'TestSidTimerSimple' or 'TestSidTimerSubclass'.
-    # Results will be the same.
+    # Test both 'TestSidTimerSimple' and 'TestSidTimerSubclass'.
+    # Results shall be the same.
+
+    print("\nTestSidTimerSimple")
     tst = TestSidTimerSimple(TIME_INTERVAL)
     try:
         time.sleep(TEST_LENGTH)  # do nothing while testing timer's accuracy
@@ -161,5 +193,17 @@ if __name__ == '__main__':
 
     # cleanup and show max errors
     tst.cancel_timer()
-    print("max positive error: ", tst.max_plus_error)
-    print("max negative error: ", tst.max_minus_error)
+    print(f"mximum too late by: {tst.max_plus_error} seconds")
+    print(f"maximum too early by: {tst.max_minus_error} seconds")
+
+    print("\nTestSidTimerSubclass")
+    tst = TestSidTimerSubclass(TIME_INTERVAL)
+    try:
+        time.sleep(TEST_LENGTH)  # do nothing while testing timer's accuracy
+    except (KeyboardInterrupt, SystemExit):
+        pass
+
+    # cleanup and show max errors
+    tst.cancel_timer()
+    print(f"mximum too late by: {tst.max_plus_error} seconds")
+    print(f"maximum too early by: {tst.max_minus_error} seconds")

--- a/supersid/supersid_scanner.py
+++ b/supersid/supersid_scanner.py
@@ -16,6 +16,7 @@ Works with pyaudio only.
 import sys
 from time import sleep
 import argparse
+from matplotlib.mlab import psd as mlab_psd
 
 # SuperSID Package classes
 from sidtimer import SidTimer
@@ -70,7 +71,6 @@ class SuperSID_scanner():
         # the same interface
         self.config['viewer'] = 'text'  # Light text version aka "console mode"
         self.viewer = textSidViewer(self)
-        self.psd = self.viewer.get_psd
 
         # calculate Stations' buffer_size
         self.buffer_size = int(24*60*60 / self.config['log_interval'])
@@ -91,8 +91,7 @@ class SuperSID_scanner():
 
         # Create Timer
         self.viewer.status_display("Waiting for Timer ... ")
-        self.timer = SidTimer(self.config['log_interval'], self.on_timer,
-                              delay=2)
+        self.timer = SidTimer(self.config['log_interval'], self.on_timer)
         self.scan_end_time = self.timer.start_time + 60 * self.scan_duration
 
     def about_app(self):
@@ -117,7 +116,7 @@ class SuperSID_scanner():
         try:
             # return a list of signal strength
             data = self.sampler.capture_1sec()
-            Pxx, freqs = self.psd(data, self.sampler.NFFT,
+            pxx, freqs = self.get_psd(data, self.sampler.NFFT,
                                   self.sampler.audio_sampling_rate)
         except IndexError as idxerr:
             print("Index Error:", idxerr)
@@ -127,7 +126,7 @@ class SuperSID_scanner():
         for channel, bin in zip(
                 self.sampler.monitored_channels,
                 self.sampler.monitored_bins):
-            signal_strengths.append(Pxx[channel][bin])
+            signal_strengths.append(pxx[channel][bin])
 
         # Save signal strengths into memory buffers
         # prepare message for status bar
@@ -147,13 +146,26 @@ class SuperSID_scanner():
                 filename=fileName,
                 log_type='raw',
                 log_format='supersid_extended')
-            print(fsaved, "saved.")
+            print(fsaved, "saved. Press 'x' to exit")
             self.close()
             sys.exit(0)
 
         # end of this thread/need to handle to View to
         # display captured data & message
         self.viewer.status_display(message)
+
+    def get_psd(self, data, nfft, fs):
+        """Call 'psd', calculates the spectrum."""
+        try:
+            pxx = {}
+            freqs = []
+            for channel in range(self.config['Channels']):
+                pxx[channel], freqs = \
+                    mlab_psd(data[:, channel], NFFT=nfft, Fs=fs)
+        except RuntimeError as err_re:
+            print("Warning:", err_re)
+            pxx, freqs = None, None
+        return pxx, freqs
 
     def save_current_buffers(self, filename='',
                              log_type='raw',


### PR DESCRIPTION
Not yet a solution but code that provokes the missing 5 second window in the test code of sidtimer.py.
This violatoin then leads to a waring that will also show up when in the real applicaton a realtime violation occurs.
In this case the relevant timestamps are printed and the operator of the station is asked to report in the issue 107.

The parameter `delay` has been removed from `SidTimer` as it causes possible variations in the behaviour that are not needed. The only user of this parameter was supersid_scanner.py.
Changes in supersid_scanner.py in order to get the code runnning again.

I would recommend to integrate this change in order to get feedback in case of hard realtime violations.