### PR TITLE
Add extra directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-Private
-Data
 *.nja
 .idea
 *.bak

--- a/Data/README.md
+++ b/Data/README.md
@@ -1,0 +1,1 @@
+This is the default directory used to hold data files.

--- a/Private/README.md
+++ b/Private/README.md
@@ -1,0 +1,1 @@
+This directory is where noaa_flares.py will cache downloaded GOES flare data.

--- a/outgoing/README.md
+++ b/outgoing/README.md
@@ -1,0 +1,1 @@
+This directory is used by ftp_to_stanford.py as temporary storage.

--- a/src/find_alsa_devices.py
+++ b/src/find_alsa_devices.py
@@ -17,7 +17,7 @@ from pprint import pprint
 import pandas as pd     # python3 -m pip install pandas
 import numpy as np
 
-from config import read_config, CONFIG_FILE_NAME
+from supersid_config import read_config, CONFIG_FILE_NAME
 from supersid_common import exist_file, slugify
 from isine import SinePlayer
 

--- a/src/ftp_to_stanford.py
+++ b/src/ftp_to_stanford.py
@@ -33,7 +33,7 @@ from os import path
 import ftplib
 from datetime import datetime, timezone, timedelta
 from sidfile import SidFile
-from config import read_config, FILTERED, RAW, CONFIG_FILE_NAME
+from supersid_config import read_config, FILTERED, RAW, CONFIG_FILE_NAME
 from supersid_common import exist_file
 
 

--- a/src/sidfile.py
+++ b/src/sidfile.py
@@ -19,7 +19,7 @@ Licence:     Open to All
 from datetime import datetime, timezone, timedelta
 import numpy
 
-from config import FILTERED, RAW
+from supersid_config import FILTERED, RAW
 from supersid_common import exist_file
 
 USAGE = """

--- a/src/supersid.py
+++ b/src/supersid.py
@@ -24,9 +24,9 @@ from matplotlib.mlab import psd as mlab_psd
 
 # SuperSID Package classes
 from sidtimer import SidTimer
-from sampler import Sampler
-from config import read_config, CONFIG_FILE_NAME
-from logger import Logger
+from supersid_sampler import Sampler
+from supersid_config import read_config, CONFIG_FILE_NAME
+from supersid_logger import Logger
 from supersid_common import exist_file, script_relative_to_cwd_relative
 
 

--- a/src/supersid_config.py
+++ b/src/supersid_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Config parses a supersid .cfg file.
+"""supersid_config parses a supersid .cfg file.
 
 Parameter access: all keys are forced to lowercase
   - for parameters: config['site_name'], config['longitude'], etc...
@@ -475,7 +475,7 @@ class Config(dict):
                       "your .cfg files.\n")
 
         # when present, 'Format' must be one of the supported formats
-        # (relevant for the format conversion in sampler.py for alsaaudio)
+        # (relevant for the format conversion in supersid_sampler.py for alsaaudio)
         if 'Format' in self:
             if self['Format'] not in [S16_LE, S24_3LE, S32_LE]:
                 self.config_ok = False

--- a/src/supersid_logger.py
+++ b/src/supersid_logger.py
@@ -16,8 +16,8 @@ import sys
 from os import path
 from time import gmtime, strftime
 from sidfile import SidFile
-from config import FILTERED, RAW, CALL_SIGN, FREQUENCY
-from config import SID_FORMAT, SUPERSID_FORMAT
+from supersid_config import FILTERED, RAW, CALL_SIGN, FREQUENCY
+from supersid_config import SID_FORMAT, SUPERSID_FORMAT
 
 
 class Logger():

--- a/src/supersid_plot.py
+++ b/src/supersid_plot.py
@@ -36,7 +36,7 @@ from email import encoders, utils
 import argparse
 # SuperSID modules
 from sidfile import SidFile
-from config import read_config, print_config, CONFIG_FILE_NAME
+from supersid_config import read_config, print_config, CONFIG_FILE_NAME
 from supersid_common import exist_file
 
 try:

--- a/src/supersid_plot_gui.py
+++ b/src/supersid_plot_gui.py
@@ -26,7 +26,7 @@ import ephem
 from sidfile import SidFile
 from noaa_flares import NOAA_flares
 from supersid_common import exist_file
-from config import read_config, print_config, CONFIG_FILE_NAME
+from supersid_config import read_config, print_config, CONFIG_FILE_NAME
 
 
 def m2hm(x, _):

--- a/src/supersid_sampler.py
+++ b/src/supersid_sampler.py
@@ -26,7 +26,7 @@ from struct import unpack as st_unpack
 from numpy import array
 from matplotlib.mlab import psd as mlab_psd
 
-from config import FREQUENCY, S16_LE, S24_3LE, S32_LE
+from supersid_config import FREQUENCY, S16_LE, S24_3LE, S32_LE
 
 
 def get_peak_freq(data, audio_sampling_rate):

--- a/src/supersid_scanner.py
+++ b/src/supersid_scanner.py
@@ -20,9 +20,9 @@ from matplotlib.mlab import psd as mlab_psd
 
 # SuperSID Package classes
 from sidtimer import SidTimer
-from sampler import Sampler
-from config import read_config, CONFIG_FILE_NAME
-from logger import Logger
+from supersid_sampler import Sampler
+from supersid_config import read_config, CONFIG_FILE_NAME
+from supersid_logger import Logger
 from textsidviewer import textSidViewer
 from supersid_common import exist_file, slugify
 
@@ -260,7 +260,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.record_sec:
-        from sampler import pyaudio_soundcard
+        from supersid_sampler import pyaudio_soundcard
         import wave
 
         config = read_config(args.config_file)

--- a/src/textsidviewer.py
+++ b/src/textsidviewer.py
@@ -13,7 +13,7 @@ import readchar
 from threading import Timer
 from time import sleep
 
-from config import FILTERED, RAW, print_config
+from supersid_config import FILTERED, RAW, print_config
 
 
 class textSidViewer:


### PR DESCRIPTION
There are 3 directories referenced in the default supersid.cfg which need to be created as part of installing supersid. Instead of forcing the user to create these, we can do it for them.