### PR TITLE
added unittest for supersid_logger

### DIFF
--- a/src/sidfile.py
+++ b/src/sidfile.py
@@ -218,7 +218,7 @@ class SidFile():
             # extended SuperSID file format: one extended time stamp then
             # one data column per station
             print(
-                "Warning: read SuperSid extended file, time stamps are read & "
+                "Info: read SuperSid extended file, time stamps are read & "
                 "converted from file.")
             inData = numpy.loadtxt(self.lines, dtype=datetime, comments='#',
                                    delimiter=",", converters=converters_dict)
@@ -236,7 +236,7 @@ class SidFile():
                     or force_read_timestamp
                     or self.is_extended):
                 print(
-                    "Warning: read SID file, timestamps are read & converted "
+                    "Info: read SID file, time stamps are read & converted "
                     "from file.")
                 inData = numpy.loadtxt(self.lines, dtype=datetime,
                                        comments='#', delimiter=",",

--- a/src/supersid_common.py
+++ b/src/supersid_common.py
@@ -29,13 +29,12 @@ def script_relative_to_cwd_relative(path):
     if os.path.isabs(path):
         # it is an absolute path, don't touch it
         return path
-    else:
-        # it is a relative path,
-        # convert it to a relative path with respect to the script folder
-        absolute_cwd = os.path.realpath(os.getcwd())
-        absolute_script_path = os.path.dirname(os.path.realpath(sys.argv[0]))
-        relative_path = os.path.relpath(absolute_script_path, absolute_cwd)
-        return os.path.normpath(os.path.join(relative_path, path))
+    # it is a relative path,
+    # convert it to a relative path with respect to the script folder
+    absolute_cwd = os.path.realpath(os.getcwd())
+    absolute_script_path = os.path.dirname(os.path.realpath(sys.argv[0]))
+    relative_path = os.path.relpath(absolute_script_path, absolute_cwd)
+    return os.path.normpath(os.path.join(relative_path, path))
 
 
 def slugify(value, allow_unicode=False):

--- a/src/supersid_logger.py
+++ b/src/supersid_logger.py
@@ -41,16 +41,14 @@ class Logger():
         # first create in memory buffers
         if len(self.config.stations) == 1:
             # only one station to monitor, let's default to SID file format
-            self.controller.isSuperSID = False
+            self.controller.isSuperSID = False  # TODO: What is this good for? Class SuperSid has no attribute isSuperSID.
             self.config["stationid"] = self.config.stations[0][CALL_SIGN]
             self.config["frequency"] = self.config.stations[0][FREQUENCY]
         elif len(self.config.stations) > 1:
             # more than one station to monitor, default to SuperSId file format
-            self.controller.isSuperSID = True
-            self.config["stations"] = \
-                ",".join([s[CALL_SIGN] for s in self.config.stations])
-            self.config["frequencies"] = \
-                ",".join([s[FREQUENCY] for s in self.config.stations])
+            self.controller.isSuperSID = True  # TODO: What is this good for? Class SuperSid has no attribute isSuperSID.
+            self.config["stations"] = ",".join([s[CALL_SIGN] for s in self.config.stations])
+            self.config["frequencies"] = ",".join([s[FREQUENCY] for s in self.config.stations])
         else:
             print("Error: no station to log???")
             sys.exit(5)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,28 @@
+"""
+common functionality for uinttest
+"""
+
+import os
+import sys
+
+
+def script_relative_to_cwd_relative(path):
+    """
+    converts a path which is meant to be relative to the script into
+    a path relative to the cwd
+    in:
+        either absolute path
+        or path relative to the script
+    out:
+        either unmodified absolute path
+        or path relative to the cwd
+    """
+    if os.path.isabs(path):
+        # it is an absolute path, don't touch it
+        return path
+    # it is a relative path,
+    # convert it to a relative path with respect to the script folder
+    absolute_cwd = os.path.realpath(os.getcwd())
+    absolute_script_path = os.path.dirname(os.path.realpath(sys.argv[0]))
+    relative_path = os.path.relpath(absolute_script_path, absolute_cwd)
+    return os.path.normpath(os.path.join(relative_path, path))

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,209 @@
+"""
+test for supersid_logger.py
+"""
+import os
+import sys
+import glob
+import shutil
+import unittest
+from datetime import datetime, timezone
+import readchar
+
+from test_common import script_relative_to_cwd_relative as relpath
+
+sys.path.append(relpath(r"../src"))
+from supersid_config import read_config, CONFIG_FILE_NAME, CALL_SIGN, FREQUENCY, FILTERED, RAW
+from supersid_logger import Logger
+from sidfile import SidFile
+
+
+class CommonLoggerTests():
+    """ common tests regard """
+    def assert_sid_files(self, log_type, extended):
+        """
+        assert the sid file properties are as expected
+        """
+        csv_files = glob.glob(self.config["data_path"] + "*.csv")
+        self.assertTrue(len(csv_files) == len(self.config.stations))
+        for station in self.config.stations:
+            call_sign = station["call_sign"]
+            csv_file = f"{self.config['data_path']}{self.config['site_name']}"\
+                       f"_{call_sign}_{self.date}.csv"
+            self.assertTrue(csv_file in csv_files)
+            sid_file = SidFile(csv_file)
+
+            self.assertEqual(sid_file.is_extended, extended)
+            # check sid_file.sid_params[key] in the order the keys appear in the .csv files
+            self.assertEqual(sid_file.sid_params["contact"], self.config["contact"])
+            self.assertEqual(sid_file.sid_params["frequency"], station["frequency"])
+            self.assertEqual(sid_file.sid_params["latitude"], self.config["latitude"])
+            self.assertEqual(int(sid_file.sid_params["loginterval"]), self.config["log_interval"])
+            self.assertEqual(sid_file.LogInterval, self.config["log_interval"])
+            self.assertEqual(sid_file.sid_params["logtype"], log_type)
+            self.assertEqual(sid_file.sid_params["longitude"], self.config["longitude"])
+            self.assertEqual(sid_file.sid_params["monitorid"], self.config["monitor_id"])
+            self.assertEqual(sid_file.sid_params["site"], self.config["site_name"])
+            self.assertEqual(sid_file.sid_params["stationid"], station["call_sign"])
+            self.assertEqual(sid_file.sid_params["timezone"], self.config["time_zone"])
+            self.assertEqual(sid_file.sid_params["utc_offset"], self.config["utc_offset"])
+            self.assertEqual(sid_file.sid_params["utc_starttime"], self.date + " 00:00:00")
+
+    def test__log_sid_format__default(self):
+        """
+        test Logger.log_sid_format()
+        with default parameters (log_type=FILTERED, extended=False)
+        """
+        self.logger.log_sid_format(self.config.stations)
+        self.assert_sid_files(log_type=FILTERED, extended=False)
+
+    def test__log_sid_format__variations(self):
+        """
+        test Logger.log_sid_format()
+        with variations of the named parameters (log_type=?, extended=?)
+        """
+        for log_type in [FILTERED, RAW]:
+            for extended in [False, True]:
+                self.logger.log_sid_format(
+                    self.config.stations,
+                    log_type=log_type,
+                    extended=extended)
+                self.assert_sid_files(log_type, extended)
+
+    def assert_supersid_file(self, filename, log_type, extended):
+        """
+        assert the supersid file properties are as expected
+        """
+        csv_files = glob.glob(self.config["data_path"] + "*.csv")
+        self.assertTrue(len(csv_files) == 1) # one file for all stations
+        if filename:
+            csv_file = filename
+        else:
+            csv_file = f"{self.config['data_path']}{self.config['site_name']}_{self.date}.csv"
+        self.assertTrue(csv_file in csv_files)
+        sid_file = SidFile(csv_file)
+
+        call_signs = []
+        frequencies = []
+        for station in self.config.stations:
+            call_signs.append(station["call_sign"])
+            frequencies.append(station["frequency"])
+        call_signs = ",".join(s for s in call_signs)
+        frequencies = ",".join(s for s in frequencies)
+
+        self.assertEqual(sid_file.is_extended, extended)
+        # check sid_file.sid_params[key] in the order the keys appear in the .csv files
+        self.assertEqual(sid_file.sid_params["contact"], self.config["contact"])
+        self.assertEqual(sid_file.sid_params["frequencies"], frequencies)
+        self.assertEqual(sid_file.sid_params["latitude"], self.config["latitude"])
+        self.assertEqual(int(sid_file.sid_params["loginterval"]), self.config["log_interval"])
+        self.assertEqual(sid_file.LogInterval, self.config["log_interval"])
+        self.assertEqual(sid_file.sid_params["logtype"], log_type)
+        self.assertEqual(sid_file.sid_params["longitude"], self.config["longitude"])
+        self.assertEqual(sid_file.sid_params["monitorid"], self.config["monitor_id"])
+        self.assertEqual(sid_file.sid_params["site"], self.config["site_name"])
+        self.assertEqual(sid_file.sid_params["stations"], call_signs)
+        self.assertEqual(sid_file.sid_params["timezone"], self.config["time_zone"])
+        self.assertEqual(sid_file.sid_params["utc_offset"], self.config["utc_offset"])
+        self.assertEqual(sid_file.sid_params["utc_starttime"], self.date + " 00:00:00")
+
+    def test__log_supersid_format__default(self):
+        """
+        test Logger.log_supersid_format()
+        with default parameters (filename='', log_type=FILTERED, extended=False)
+        """
+        self.logger.log_supersid_format(self.config.stations)
+        self.assert_supersid_file(filename='', log_type=FILTERED, extended=False)
+
+    def test__log_supersid_format__variations(self):
+        """
+        test Logger.log_supersid_format()
+        with variations of the named parameters (filename='', log_type=?, extended=?)
+        """
+        for filename in ["", "test.csv", os.path.abspath(f"{self.config['data_path']}test.csv")]:
+            for log_type in [FILTERED, RAW]:
+                for extended in [False, True]:
+                    csv_files = glob.glob(self.config["data_path"] + "*.csv")
+                    for file in csv_files:
+                        os.remove(file)
+                    self.logger.log_supersid_format(
+                        self.config.stations,
+                        filename=filename,
+                        log_type=log_type,
+                        extended=extended)
+                    if filename:
+                        if os.path.isabs(filename):
+                            rel_name = f"{self.config['data_path']}{os.path.split(filename)[-1]}"
+                        else:
+                            rel_name = f"{self.config['data_path']}{filename}"
+                    else:
+                        rel_name = filename # use empty filename as is
+                    self.assert_supersid_file(
+                        filename=rel_name,
+                        log_type=log_type,
+                        extended=extended)
+
+
+class TestOneStation(unittest.TestCase, CommonLoggerTests):
+    """ tests class Logger with one station in spersid.cfg """
+    def setUp(self):
+        """ generic setup for all tests """
+        if os.path.isfile(CONFIG_FILE_NAME):
+            os.remove(CONFIG_FILE_NAME)
+        shutil.copy2(relpath("test_logger_1_station.cfg"), CONFIG_FILE_NAME)
+        self.config = read_config(CONFIG_FILE_NAME)
+        self.logger = Logger(self)
+        self.date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        csv_files = glob.glob(self.config["data_path"] + "*.csv")
+        for file in csv_files:
+            os.remove(file)
+
+    def test__init(self):
+        """ test Logger.__init__() """
+        self.assertEqual(self.config["stationid"], self.config.stations[0][CALL_SIGN])
+        self.assertEqual(self.config["frequency"], self.config.stations[0][FREQUENCY])
+        self.assertEqual(self.config["data_path"], relpath("../Data") + os.sep)
+
+
+class TestTwoStations(unittest.TestCase, CommonLoggerTests):
+    """ tests class Logger with two stations in spersid.cfg """
+    def setUp(self):
+        """ generic setup for all tests """
+        if os.path.isfile(CONFIG_FILE_NAME):
+            os.remove(CONFIG_FILE_NAME)
+        shutil.copy2(relpath("test_logger_2_stations.cfg"), CONFIG_FILE_NAME)
+        self.config = read_config(CONFIG_FILE_NAME)
+        self.logger = Logger(self)
+        self.date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        csv_files = glob.glob(self.config["data_path"] + "*.csv")
+        for file in csv_files:
+            os.remove(file)
+
+    def test_init(self):
+        """ test Logger.__init__() """
+        self.assertEqual(self.config["stations"],
+                         ",".join([s[CALL_SIGN] for s in self.config.stations]))
+        self.assertEqual(self.config["frequencies"],
+                         ",".join([s[FREQUENCY] for s in self.config.stations]))
+        self.assertEqual(self.config["data_path"], relpath("../Data") + os.sep)
+
+
+def main():
+    """ the main function """
+    warning = "This test will modify and/or delete the content of 'Config' and 'Data' folders.\n" \
+              "It is up to you to take backups.\n" \
+              "Do you want to continue (Y|n)?"
+    print(warning)
+
+    while True:
+        ch = readchar.readkey().lower()
+        if ch in ['y', chr(0x0D), chr(0x0A)]:
+            # shutil.copy2(r"../Config/supersid.cfg", r"../Config/supersid.test_logger.bak")
+            unittest.main()
+            # shutil.copy2(r"../Config/supersid.test_logger.bak", r"../Config/supersid.cfg")
+        elif 'n' == ch:
+            sys.exit()
+        else:
+            print(warning)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_logger_1_station.cfg
+++ b/tests/test_logger_1_station.cfg
@@ -1,0 +1,93 @@
+# This is a comment with a hash.
+; This is another comment with a semicolon.
+# Comments are added only for demonstration purpose.
+
+[PARAMETERS]
+# viewer = tk
+viewer = text
+site_name = EXAMPLE
+monitor_id = SAMPLE1
+contact = you@domain.tld
+
+# coordinates of your station, example: Greenwich
+longitude = -0.001
+latitude = 51.478
+utc_offset = +00:00
+time_zone = UTC
+
+# typically one of 44100, 48000, 96000, 192000
+audio_sampling_rate = 48000
+
+log_interval = 5
+log_format = supersid_extended
+log_type = filtered
+scaling_factor = 1.0
+
+# fixed y axis for the tk viewer (float value)
+psd_min = NaN
+psd_max = NaN
+psd_ticks = 0
+
+# Waterfall diagram 0: disabled
+# >= 1: number of samples displayed (one per log_interval seconds)
+# 15 minutes with log_interval = 5 results in waterfall_samples = 15 * 60 / 5 = 180
+waterfall_samples = 0
+
+hourly_save = YES
+
+# data_path shall be an absolute path or a path relative to the src script folder
+data_path = ../Data
+
+paper_size = A4
+
+# VLF station data is gathered from two sources:
+# https://www.mwlist.org/vlf.php
+# https://sidstation.loudet.org/stations-list-en.xhtml
+# In case of contradictions, sidstation.loudet.org is used.
+
+[STATION]
+# https://www.mwlist.org/vlf.php?kHz=19.80
+# https://sidstation.loudet.org/stations-list-en.xhtml 19800 = NWC
+# Harold E. Holt, North West Cape, Exmouth, Australia @-21.816328,+114.165586
+# https://www.luftlinie.org/51.478,-0.001/-21.816328,+114.165586
+# 13547 km
+# 24h
+call_sign = NWC
+color = y
+frequency = 19800
+channel = 0
+
+[Capture]
+# Linux example using alsaaudio
+# Audio = alsaaudio
+# Device = plughw:CARD=Generic,DEV=0
+# Format = S16_LE
+# PeriodSize = 1024
+# Channels = 1
+
+# Windows example using either sounddevice or pyaudio
+# Audio = sounddevice
+# Audio = pyaudio
+# Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
+# Format = S32_LE
+# Channels = 1
+
+[FTP]
+automatic_upload = no
+ftp_server = sid-ftp.stanford.edu
+ftp_directory = /incoming/SuperSID/NEW/
+# local_tmp shall be an absolute path or a path relative to the src script folder
+local_tmp = ../outgoing
+call_signs = NWC
+
+[Email]
+# required to connect to the mail server when using 'supersid_plot.py -e receiver@domain.tld'
+from_mail = you@domain.tld
+email_server = mail.domain.tld
+email_port = 587
+email_tls = yes
+email_login = your_user_name
+email_password = your_password
+
+# email_server for gmail would be smtp.gmail.com  
+# email_port for gmail would be 587  

--- a/tests/test_logger_2_stations.cfg
+++ b/tests/test_logger_2_stations.cfg
@@ -1,0 +1,104 @@
+# This is a comment with a hash.
+; This is another comment with a semicolon.
+# Comments are added only for demonstration purpose.
+
+[PARAMETERS]
+# viewer = tk
+viewer = text
+site_name = EXAMPLE
+monitor_id = SAMPLE1
+contact = you@domain.tld
+
+# coordinates of your station, example: Greenwich
+longitude = -0.001
+latitude = 51.478
+utc_offset = +00:00
+time_zone = UTC
+
+# typically one of 44100, 48000, 96000, 192000
+audio_sampling_rate = 48000
+
+log_interval = 5
+log_format = supersid_extended
+log_type = filtered
+scaling_factor = 1.0
+
+# fixed y axis for the tk viewer (float value)
+psd_min = NaN
+psd_max = NaN
+psd_ticks = 0
+
+# Waterfall diagram 0: disabled
+# >= 1: number of samples displayed (one per log_interval seconds)
+# 15 minutes with log_interval = 5 results in waterfall_samples = 15 * 60 / 5 = 180
+waterfall_samples = 0
+
+hourly_save = YES
+
+# data_path shall be an absolute path or a path relative to the src script folder
+data_path = ../Data
+
+paper_size = A4
+
+# VLF station data is gathered from two sources:
+# https://www.mwlist.org/vlf.php
+# https://sidstation.loudet.org/stations-list-en.xhtml
+# In case of contradictions, sidstation.loudet.org is used.
+
+[STATION]
+# https://www.mwlist.org/vlf.php?kHz=19.80
+# https://sidstation.loudet.org/stations-list-en.xhtml 19800 = NWC
+# Harold E. Holt, North West Cape, Exmouth, Australia @-21.816328,+114.165586
+# https://www.luftlinie.org/51.478,-0.001/-21.816328,+114.165586
+# 13547 km
+# 24h
+call_sign = NWC
+color = y
+frequency = 19800
+channel = 0
+
+[STATION]
+# https://www.mwlist.org/vlf.php?kHz=18.20
+# https://sidstation.loudet.org/stations-list-en.xhtml 18200 = VTX3
+# South Vijayanarayanam, India @+08.387015,+077.752762
+# https://www.luftlinie.org/51.478,-0.001/+08.387015,+077.752762
+# 8432 km
+call_sign = VTX3
+color = k
+frequency = 18200
+channel = 0
+
+[Capture]
+# Linux example using alsaaudio
+# Audio = alsaaudio
+# Device = plughw:CARD=Generic,DEV=0
+# Format = S16_LE
+# PeriodSize = 1024
+# Channels = 1
+
+# Windows example using either sounddevice or pyaudio
+# Audio = sounddevice
+# Audio = pyaudio
+# Device = Windows WASAPI: Mikrofon (Realtek High Definition Audio)
+# Format = S32_LE
+# Channels = 1
+
+[FTP]
+automatic_upload = no
+ftp_server = sid-ftp.stanford.edu
+ftp_directory = /incoming/SuperSID/NEW/
+# local_tmp shall be an absolute path or a path relative to the src script folder
+local_tmp = ../outgoing
+call_signs = NWC
+
+[Email]
+# required to connect to the mail server when using 'supersid_plot.py -e receiver@domain.tld'
+from_mail = you@domain.tld
+email_server = mail.domain.tld
+email_port = 587
+email_tls = yes
+email_login = your_user_name
+email_password = your_password
+
+# email_server for gmail would be smtp.gmail.com  
+# email_port for gmail would be 587  


### PR DESCRIPTION
Investigation for https://github.com/sberl/supersid/issues/68

Even with the unittest for supersid_logger I could not find any way to write sid or supersid files into a wrong folder.

One possible exception is there: `log_supersid_format()` accepts a `fielname` as parameter. If this is an absolute path outside the `Data` folder, it will be used.

But the image [here](https://github.com/sberl/supersid/issues/68#issuecomment-1497119394) suggests that sid files were placed in the worng folder, not supersid files.

I cannot find the way, how this could happen.

The test has been executed on Windows as `python test_logger.py`.